### PR TITLE
Use RandomState instead of random.seed

### DIFF
--- a/imgviz/label.py
+++ b/imgviz/label.py
@@ -92,12 +92,10 @@ def label2rgb(
 
     res = colormap[label]
 
-    np.random.seed(1234)
+    random_state = np.random.RandomState(seed=1234)
 
     mask_unlabeled = label < 0
-    res[mask_unlabeled] = (
-        np.random.random(size=(mask_unlabeled.sum(), 3)) * 255
-    )
+    res[mask_unlabeled] = random_state.rand(*(mask_unlabeled.sum(), 3)) * 255
 
     if img is not None:
         if img.ndim == 2:


### PR DESCRIPTION
`np.random.seed` is internally called in `label2rgb` function.
If `np.random.seed` is called, random function called, outside of this function,  will be affected.

# Without This PR
```
In [1]: import numpy as np
   ...: import imgviz
   ...:
   ...: mask = np.zeros((100, 100, 3), dtype=np.int32)
   ...: imgviz.label2rgb(mask)
   ...: print(np.random.random())
   ...: imgviz.label2rgb(mask)
   ...: print(np.random.random())
   ...:
0.1915194503788923
0.1915194503788923
```

# With this PR
```
In [1]: import numpy as np
   ...: import imgviz
   ...:
   ...: mask = np.zeros((100, 100, 3), dtype=np.int32)
   ...: imgviz.label2rgb(mask)
   ...: print(np.random.random())
   ...: imgviz.label2rgb(mask)
   ...: print(np.random.random())
   ...:
0.6090582137312623
0.7448168451875224
```
