### PR TITLE
 Remove padding from instances2rgb

### DIFF
--- a/imgviz/data/arc2017/__init__.py
+++ b/imgviz/data/arc2017/__init__.py
@@ -28,7 +28,7 @@ def arc2017():
         "res4"
     ]
 
-    with open(osp.join(here, "camera_info.yaml") ) as f:
+    with open(osp.join(here, "camera_info.yaml")) as f:
         data["camera_info"] = yaml.safe_load(f)
 
     return data

--- a/imgviz/instances.py
+++ b/imgviz/instances.py
@@ -27,6 +27,7 @@ def instances2rgb(
     boundary_width=1,
     alpha=0.7,
     colormap=None,
+    font_path=None,
 ):
     """Convert instances to rgb.
 
@@ -125,13 +126,31 @@ def instances2rgb(
         )
 
         if caption is not None:
+            for loc in ["lt+", "lt"]:
+                y1, x1, y2, x2 = draw_module.text_in_rectangle_aabb(
+                    src=dst,
+                    loc=loc,
+                    text=caption,
+                    size=font_size,
+                    aabb1=aabb1,
+                    aabb2=aabb2,
+                    font_path=font_path,
+                )
+                if (
+                    y1 >= 0
+                    and x1 >= 0
+                    and y2 < dst.shape[0]
+                    and x2 < dst.shape[1]
+                ):
+                    break
             dst = draw_module.text_in_rectangle(
-                dst,
-                loc="lt+",
+                src=dst,
+                loc=loc,
                 text=caption,
                 size=font_size,
                 background=color_cls,
                 aabb1=aabb1,
                 aabb2=aabb2,
+                font_path=font_path,
             )
     return dst


### PR DESCRIPTION
Close #28 

![Figure_1](https://user-images.githubusercontent.com/4310419/85973393-7bd04300-b9ca-11ea-95ff-861026e243dc.png)

```python
#!/usr/bin/env python

import matplotlib.pyplot as plt

import imgviz


def instances2rgb():
    data = imgviz.data.voc()

    # captions = [data["class_names"][l] for l in data["labels"]]
    insviz1 = imgviz.instances2rgb(
        image=data["rgb"],
        bboxes=[[0, 0, 30, 50]],
        labels=[1],
        captions=["left_top_obj"],
        font_size=15,
        line_width=2,
    )
    # insviz2 = imgviz.instances2rgb(
    #     image=data["rgb"],
    #     masks=data["masks"] == 1,
    #     labels=data["labels"],
    #     captions=captions,
    # )

    # -------------------------------------------------------------------------

    plt.figure(dpi=200)

    plt.subplot(121)
    plt.title("rgb")
    plt.imshow(data["rgb"])
    plt.axis("off")

    plt.subplot(122)
    plt.title("instances\n(bboxes)")
    plt.imshow(insviz1)
    plt.axis("off")

    # plt.subplot(133)
    # plt.title("instances\n(masks)")
    # plt.imshow(insviz2)
    # plt.axis("off")

    img = imgviz.io.pyplot_to_numpy()
    plt.close()

    return img


if __name__ == "__main__":
    from base import run_example

    run_example(instances2rgb)
```