### PR TITLE
refactor!: rename Depth2RGB to Depth2Rgb, Nchannel2RGB to Nchannel2Rgb

### DIFF
--- a/imgviz/__init__.py
+++ b/imgviz/__init__.py
@@ -17,7 +17,7 @@ from ._color import rgb2gray
 from ._color import rgb2hsv
 from ._color import rgb2rgba
 from ._color import rgba2rgb
-from ._depth import Depth2RGB
+from ._depth import Depth2Rgb
 from ._depth import depth2rgb
 from ._dtype import bool2ubyte
 from ._dtype import float2ubyte
@@ -26,7 +26,7 @@ from ._instances import instances2rgb
 from ._instances import masks_to_bboxes
 from ._label import label2rgb
 from ._label import label_colormap
-from ._nchannel import Nchannel2RGB
+from ._nchannel import Nchannel2Rgb
 from ._nchannel import nchannel2rgb
 from ._normalize import normalize
 from ._resize import resize

--- a/imgviz/_depth.py
+++ b/imgviz/_depth.py
@@ -10,7 +10,7 @@ from numpy.typing import NDArray
 from ._normalize import normalize
 
 
-class Depth2RGB:
+class Depth2Rgb:
     """Convert depth array to rgb.
 
     Parameters
@@ -119,4 +119,4 @@ def depth2rgb(
         Colorized image with shape (H, W, 3).
 
     """
-    return Depth2RGB(min_value, max_value, colormap)(depth, dtype)
+    return Depth2Rgb(min_value, max_value, colormap)(depth, dtype)

--- a/imgviz/_nchannel.py
+++ b/imgviz/_nchannel.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     import sklearn.decomposition
 
 
-class Nchannel2RGB:
+class Nchannel2Rgb:
     """Convert nchannel array to rgb by PCA.
 
     Parameters
@@ -105,4 +105,4 @@ def nchannel2rgb(
         Visualized image with shape (H, W, 3).
 
     """
-    return Nchannel2RGB(pca)(nchannel, dtype)
+    return Nchannel2Rgb(pca)(nchannel, dtype)


### PR DESCRIPTION
Use consistent naming convention with Rgb instead of RGB.

BREAKING CHANGE: Class names changed from Depth2RGB to Depth2Rgb and Nchannel2RGB to Nchannel2Rgb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)