### PR TITLE
refactor(label)!: simplify label_colormap function

### DIFF
--- a/examples/draw.py
+++ b/examples/draw.py
@@ -33,7 +33,7 @@ def draw() -> None:
     # mouse segment
     viz = imgviz.draw.line(viz, yx=[yxs[3], yxs[4]], fill=(255, 255, 255), width=5)
 
-    colors = imgviz.label_colormap(value=255)[1:]
+    colors = imgviz.label_colormap()[1:]
     shapes = ["star", "ellipse", "rectangle", "circle", "triangle"]
     for yx, color, shape in zip(yxs, colors, shapes):
         size = 20

--- a/imgviz/_io.py
+++ b/imgviz/_io.py
@@ -71,7 +71,7 @@ def lblsave(filename: str | pathlib.Path, lbl: np.ndarray) -> None:
         raise ValueError(f"lbl.dtype must be np.uint8, but got {lbl.dtype}")
 
     lbl_pil = PIL.Image.fromarray(lbl, mode="P")
-    colormap = label_colormap(n_label=256)
+    colormap = label_colormap()
     lbl_pil.putpalette(colormap.flatten())
     lbl_pil.save(filename)
 


### PR DESCRIPTION
## Summary

- Remove `n_label` parameter (always generates 256 labels)
- Remove `value` parameter (HSV brightness adjustment)
- Add `@functools.lru_cache` for performance optimization
- Move `bitget` to module-level `_bitget()` with type hints

This is a **breaking change** that simplifies the API:

```python
# Before
label_colormap(n_label=256, value=None)

# After
label_colormap()
```

## Test plan

- [x] All existing tests pass
- [x] Updated all internal callers (`_io.py`, `examples/draw.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)