### PR TITLE
feat(types): add overload signatures for depth2rgb

### DIFF
--- a/imgviz/_depth.py
+++ b/imgviz/_depth.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import typing
 from collections.abc import Callable
 
 import cmap
 import numpy as np
-from numpy.typing import DTypeLike
 from numpy.typing import NDArray
 
 from ._normalize import normalize
@@ -39,8 +39,36 @@ class Depth2Rgb:
         """Maximum value of depth."""
         return self._max_value
 
+    @typing.overload
     def __call__(
-        self, depth: NDArray, dtype: DTypeLike = np.uint8
+        self,
+        depth: NDArray,
+        dtype: type[np.uint8] = ...,
+    ) -> NDArray[np.uint8]: ...
+
+    @typing.overload
+    def __call__(
+        self,
+        depth: NDArray,
+        dtype: type[np.float32],
+    ) -> NDArray[np.float32]: ...
+
+    @typing.overload
+    def __call__(
+        self,
+        depth: NDArray,
+        dtype: type[np.float64],
+    ) -> NDArray[np.float64]: ...
+
+    @typing.overload
+    def __call__(
+        self,
+        depth: NDArray,
+        dtype: type[np.floating],
+    ) -> NDArray[np.floating]: ...
+
+    def __call__(
+        self, depth: NDArray, dtype: type[np.uint8] | type[np.floating] = np.uint8
     ) -> NDArray[np.uint8] | NDArray[np.floating]:
         """Convert depth array to rgb.
 
@@ -85,12 +113,52 @@ class Depth2Rgb:
         return rgb
 
 
+@typing.overload
+def depth2rgb(
+    depth: NDArray,
+    min_value: float | NDArray | None = ...,
+    max_value: float | NDArray | None = ...,
+    colormap: str | Callable[[NDArray], NDArray] = ...,
+    dtype: type[np.uint8] = ...,
+) -> NDArray[np.uint8]: ...
+
+
+@typing.overload
+def depth2rgb(
+    depth: NDArray,
+    min_value: float | NDArray | None = ...,
+    max_value: float | NDArray | None = ...,
+    colormap: str | Callable[[NDArray], NDArray] = ...,
+    dtype: type[np.float32] = ...,
+) -> NDArray[np.float32]: ...
+
+
+@typing.overload
+def depth2rgb(
+    depth: NDArray,
+    min_value: float | NDArray | None = ...,
+    max_value: float | NDArray | None = ...,
+    colormap: str | Callable[[NDArray], NDArray] = ...,
+    dtype: type[np.float64] = ...,
+) -> NDArray[np.float64]: ...
+
+
+@typing.overload
+def depth2rgb(
+    depth: NDArray,
+    min_value: float | NDArray | None = ...,
+    max_value: float | NDArray | None = ...,
+    colormap: str | Callable[[NDArray], NDArray] = ...,
+    dtype: type[np.floating] = ...,
+) -> NDArray[np.floating]: ...
+
+
 def depth2rgb(
     depth: NDArray,
     min_value: float | NDArray | None = None,
     max_value: float | NDArray | None = None,
     colormap: str | Callable[[NDArray], NDArray] = "jet",
-    dtype: DTypeLike = np.uint8,
+    dtype: type[np.uint8] | type[np.floating] = np.uint8,
 ) -> NDArray[np.uint8] | NDArray[np.floating]:
     """Convert depth to rgb.
 

--- a/tests/unit/_depth_test.py
+++ b/tests/unit/_depth_test.py
@@ -1,13 +1,22 @@
 import numpy as np
+import pytest
 
 import imgviz
 
 
-def test_depth2rgb() -> None:
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32, np.float64])
+def test_depth2rgb(dtype: type[np.uint8] | type[np.floating]) -> None:
     data = imgviz.data.arc2017()
 
-    depthviz = imgviz.depth2rgb(data["depth"])
+    depthviz = imgviz.depth2rgb(data["depth"], dtype=dtype)
 
-    assert depthviz.dtype == np.uint8
+    assert depthviz.dtype == dtype
     H, W = data["depth"].shape[:2]
     assert depthviz.shape == (H, W, 3)
+
+
+def test_depth2rgb_invalid_dtype() -> None:
+    data = imgviz.data.arc2017()
+
+    with pytest.raises(ValueError, match="dtype must be"):
+        imgviz.depth2rgb(data["depth"], dtype=np.int32)  # type: ignore[call-overload]


### PR DESCRIPTION
## Summary
- Add `@typing.overload` signatures to `Depth2Rgb.__call__` and `depth2rgb` so callers get precise return types (`NDArray[np.uint8]`, `NDArray[np.float32]`, `NDArray[np.float64]`, `NDArray[np.floating]`) based on the `dtype` argument
- Replace `DTypeLike` with `type[np.uint8] | type[np.floating]` in implementation signatures for proper type narrowing
- Add parametrized tests covering `np.uint8`, `np.float32`, `np.float64` and an invalid dtype error path

## Why
Without overloads, callers always get `NDArray[np.uint8] | NDArray[np.floating]` regardless of what `dtype` they pass, losing type precision.

## Test plan
- [x] `uv run ty check --no-progress` passes
- [x] `uv run pytest tests/unit/_depth_test.py -v` — 4 tests pass (uint8, float32, float64, invalid dtype)
- [x] `uv run ruff check` and `uv run ruff format --check` pass