### PR TITLE
feat(draw): add polygon primitive

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,13 +62,29 @@ downstream task, it belongs in a library that depends on `imgviz`, not in
   imgviz.colorize(scalar, vmin=None, vmax=None, cmap="viridis")
   ```
 
+- **`imgviz.draw.polygon`** — filled and/or outlined polygon primitive.
+  Accepts `(N, 2)` `(y, x)` vertices and the standard `fill` / `outline` /
+  `width` triple matching `rectangle`. Closes
+  [#92](https://github.com/wkentaro/imgviz/issues/92). The polyline rename
+  (`draw.line` → `draw.polyline` with a `line` alias) remains planned.
+
+  ```python
+  imgviz.draw.polygon(image, yx, fill=None, outline=None, width=1)
+  ```
+
 ## Planned primitives
 
-### Polygon and polyline
+### Polyline rename
 
-`draw.polygon`, `draw.polygon_`, `draw.polyline`, `draw.polyline_`. Accept
-`(N, 2)` points. Integrate with the `Fill` system so any pattern can fill any
-polygon. Closes [#92](https://github.com/wkentaro/imgviz/issues/92).
+Rename `draw.line` → `draw.polyline` (keeping `line` as an alias) so the
+N-point semantics are obvious from the name. Pairs with the shipped
+`draw.polygon` to make the polygon/polyline family consistent.
+
+### `Fill`-pattern integration for polygon
+
+Extend `draw.polygon`'s `fill` to accept any `Fill` pattern (stripe, checker,
+gradient, etc.) so arbitrary patterns can fill any polygon. Lands with the
+broader `Fill` work below.
 
 ### Keypoints with edges
 

--- a/examples/draw.py
+++ b/examples/draw.py
@@ -1,8 +1,23 @@
 #!/usr/bin/env python
 
+import math
+
 import matplotlib.pyplot as plt
 
 import imgviz
+
+
+def _regular_polygon_yx(
+    center: tuple[float, float], radius: float, n_sides: int
+) -> list[tuple[float, float]]:
+    cy, cx = center
+    return [
+        (
+            cy + radius * math.sin(math.radians(a)),
+            cx + radius * math.cos(math.radians(a)),
+        )
+        for a in (i * 360 / n_sides for i in range(n_sides))
+    ]
 
 
 def draw() -> None:
@@ -32,6 +47,14 @@ def draw() -> None:
     viz = imgviz.draw.line(viz, yx=[yxs[0], yxs[1]], fill=(255, 255, 255), width=5)
     # mouse segment
     viz = imgviz.draw.line(viz, yx=[yxs[3], yxs[4]], fill=(255, 255, 255), width=5)
+
+    face_padding = 30
+    octagon_yx = _regular_polygon_yx(
+        center=((y1 + y2) / 2, (x1 + x2) / 2),
+        radius=math.hypot(y2 - y1, x2 - x1) / 2 + face_padding,
+        n_sides=8,
+    )
+    viz = imgviz.draw.polygon(viz, yx=octagon_yx, outline=(255, 255, 0), width=3)
 
     colors = imgviz.label_colormap()[1:]
     shapes = ["star", "ellipse", "rectangle", "circle", "triangle"]

--- a/imgviz/draw/__init__.py
+++ b/imgviz/draw/__init__.py
@@ -5,6 +5,8 @@ from ._ellipse import ellipse_
 from ._ink import Ink
 from ._line import line
 from ._line import line_
+from ._polygon import polygon
+from ._polygon import polygon_
 from ._rectangle import rectangle
 from ._rectangle import rectangle_
 from ._star import star

--- a/imgviz/draw/_polygon.py
+++ b/imgviz/draw/_polygon.py
@@ -1,0 +1,75 @@
+import numpy as np
+import PIL.Image
+import PIL.ImageDraw
+from numpy.typing import ArrayLike
+from numpy.typing import NDArray
+
+from .. import _utils
+from ._ink import Ink
+from ._ink import get_pil_ink
+from ._ink import require_fill_or_outline
+
+
+def polygon(
+    image: NDArray[np.uint8],
+    yx: ArrayLike,
+    fill: Ink | None = None,
+    outline: Ink | None = None,
+    width: int = 1,
+) -> NDArray[np.uint8]:
+    """Draw polygon on numpy array with Pillow.
+
+    Args:
+        image: Input image.
+        yx: Array of vertices (y, x) with shape (N, 2). The polygon is closed
+            automatically; the first vertex does not need to be repeated.
+        fill: RGB color to fill the polygon. None for no fill.
+        outline: RGB color to draw the outline. None for no outline.
+        width: Outline width.
+
+    Returns:
+        Output image.
+    """
+    dst = _utils.numpy_to_pillow(image)
+    polygon_(image=dst, yx=yx, fill=fill, outline=outline, width=width)
+    return _utils.pillow_to_numpy(dst)
+
+
+def polygon_(
+    image: PIL.Image.Image,
+    yx: ArrayLike,
+    fill: Ink | None = None,
+    outline: Ink | None = None,
+    width: int = 1,
+) -> None:
+    """Draw polygon on PIL image in-place.
+
+    Args:
+        image: PIL image to draw on (modified in-place).
+        yx: Array of vertices (y, x) with shape (N, 2). The polygon is closed
+            automatically; the first vertex does not need to be repeated.
+        fill: RGB color to fill the polygon. None for no fill.
+        outline: RGB color to draw the outline. None for no outline.
+        width: Outline width.
+    """
+    if not isinstance(image, PIL.Image.Image):
+        raise TypeError(
+            f"image must be PIL.Image.Image, but got {type(image).__name__}"
+        )
+    require_fill_or_outline(fill, outline)
+    yx = np.asarray(yx)
+    if yx.ndim != 2:
+        raise ValueError(f"yx must be 2D array, but got {yx.ndim}D")
+    if yx.shape[1] != 2:
+        raise ValueError(f"yx.shape[1] must be 2, but got {yx.shape[1]}")
+    if yx.shape[0] < 3:
+        raise ValueError(f"yx must have at least 3 vertices, but got {yx.shape[0]}")
+
+    xy = yx[:, ::-1].flatten().tolist()
+    draw = PIL.ImageDraw.Draw(image)
+    draw.polygon(
+        xy=xy,
+        fill=get_pil_ink(fill),
+        outline=get_pil_ink(outline),
+        width=width,
+    )

--- a/tests/unit/draw/_polygon_test.py
+++ b/tests/unit/draw/_polygon_test.py
@@ -1,0 +1,92 @@
+import numpy as np
+import PIL.Image
+import pytest
+from numpy.typing import NDArray
+
+import imgviz
+
+
+@pytest.fixture
+def white_image() -> NDArray[np.uint8]:
+    return np.full((100, 100, 3), 255, dtype=np.uint8)
+
+
+def test_polygon_outline_only(white_image: NDArray[np.uint8]) -> None:
+    res = imgviz.draw.polygon(
+        white_image, yx=[(10, 10), (10, 90), (90, 90), (90, 10)], outline=(0, 0, 0)
+    )
+    assert res.shape == white_image.shape
+    assert res.dtype == white_image.dtype
+    top_edge = res[10, 40:60]
+    assert ((top_edge == (0, 0, 0)).all(axis=-1)).any()
+
+
+def test_polygon_fill_only(white_image: NDArray[np.uint8]) -> None:
+    res = imgviz.draw.polygon(
+        white_image, yx=[(10, 10), (10, 90), (90, 50)], fill=(255, 0, 0)
+    )
+    assert (res[50, 50] == (255, 0, 0)).all()
+
+
+def test_polygon_fill_and_outline_with_width(
+    white_image: NDArray[np.uint8],
+) -> None:
+    res = imgviz.draw.polygon(
+        white_image,
+        yx=[(10, 10), (10, 90), (90, 90), (90, 10)],
+        fill=(0, 255, 0),
+        outline=(0, 0, 255),
+        width=3,
+    )
+    assert (res[50, 50] == (0, 255, 0)).all()
+    top_edge = res[10, 40:60]
+    assert ((top_edge == (0, 0, 255)).all(axis=-1)).any()
+
+
+def test_polygon_accepts_ndarray_yx(white_image: NDArray[np.uint8]) -> None:
+    yx = np.array([[10, 10], [10, 90], [90, 50]], dtype=np.float32)
+    res = imgviz.draw.polygon(white_image, yx=yx, fill=(0, 0, 0))
+    assert not np.array_equal(res, white_image)
+
+
+def test_polygon_rejects_non_2d_yx(white_image: NDArray[np.uint8]) -> None:
+    with pytest.raises(ValueError, match="yx must be 2D"):
+        imgviz.draw.polygon(white_image, yx=[10, 10, 10, 90], fill=(0, 0, 0))
+
+
+def test_polygon_rejects_wrong_inner_dim(
+    white_image: NDArray[np.uint8],
+) -> None:
+    with pytest.raises(ValueError, match=r"yx.shape\[1\] must be 2"):
+        imgviz.draw.polygon(white_image, yx=[(10, 10, 0), (10, 90, 0)], fill=(0, 0, 0))
+
+
+def test_polygon_underscore_rejects_numpy_image(
+    white_image: NDArray[np.uint8],
+) -> None:
+    with pytest.raises(TypeError, match="image must be PIL.Image.Image"):
+        imgviz.draw.polygon_(
+            white_image,  # type: ignore[arg-type]
+            yx=[(10, 10), (10, 90), (90, 50)],
+            fill=(0, 0, 0),
+        )
+
+
+def test_polygon_underscore_mutates_in_place(
+    white_image: NDArray[np.uint8],
+) -> None:
+    pil = PIL.Image.fromarray(white_image)
+    imgviz.draw.polygon_(pil, yx=[(10, 10), (10, 90), (90, 50)], fill=(0, 0, 0))
+    assert not np.array_equal(np.array(pil), white_image)
+
+
+def test_polygon_rejects_missing_fill_and_outline(
+    white_image: NDArray[np.uint8],
+) -> None:
+    with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):
+        imgviz.draw.polygon(white_image, yx=[(10, 10), (10, 90), (90, 50)])
+
+
+def test_polygon_rejects_too_few_vertices(white_image: NDArray[np.uint8]) -> None:
+    with pytest.raises(ValueError, match="at least 3 vertices"):
+        imgviz.draw.polygon(white_image, yx=[(10, 10), (10, 90)], fill=(0, 0, 0))


### PR DESCRIPTION
## Summary
- Add `draw.polygon` / `draw.polygon_` taking `(N, 2)` `(y, x)` vertices with the standard `fill` / `outline` / `width` triple
- Octagon overlay in `examples/draw.py`
- ROADMAP updated: polygon shipped; polyline rename and `Fill`-pattern integration remain planned

Closes #92.

## Test plan
- [x] `uv run pytest` — 83 passing
- [x] `uv run ruff check` — clean
- [x] `examples/draw.py` rendered and visually inspected