### PR TITLE
fix: avoid IndexError in label2rgb when label has only -1

### DIFF
--- a/imgviz/_label.py
+++ b/imgviz/_label.py
@@ -79,7 +79,7 @@ def label2rgb(
     res[mask_unlabeled] = random_state.rand(*(mask_unlabeled.sum(), 3)) * 255
 
     unique_labels = np.unique(label)
-    max_label_id = unique_labels[-1]
+    max_label_id = max(int(unique_labels[-1]), 0)
 
     if isinstance(alpha, (int, float)):
         alpha_arr = np.array([alpha for _ in range(max_label_id + 1)])

--- a/tests/unit/_label_test.py
+++ b/tests/unit/_label_test.py
@@ -55,3 +55,15 @@ def test_label2rgb() -> None:
         )
         assert labelviz.dtype == np.uint8
         assert labelviz.shape == (H, W, 3)
+
+
+def test_label2rgb_all_unlabeled() -> None:
+    label = np.full((8, 8), -1, dtype=np.int32)
+    labelviz = imgviz.label2rgb(label=label)
+    assert labelviz.dtype == np.uint8
+    assert labelviz.shape == (8, 8, 3)
+
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    labelviz = imgviz.label2rgb(label=label, image=image)
+    assert labelviz.dtype == np.uint8
+    assert labelviz.shape == (8, 8, 3)


### PR DESCRIPTION
## Summary
- Clamp `max_label_id` to a minimum of 0 in `imgviz/_label.py` so `alpha_arr` is never empty when the label array contains only `-1`.
- Add `test_label2rgb_all_unlabeled` covering the all-unlabeled case with and without an `image`.

## Why
When `label` consisted entirely of `-1`, `unique_labels[-1]` was `-1`, making `alpha_arr` an empty array. The subsequent `alpha_arr[label]` lookup then raised `IndexError: index -1 is out of bounds for axis 0 with size 0`.

## Test plan
- [x] Reproduced the original `IndexError` on `main`.
- [x] `pytest tests/unit/_label_test.py` passes (2 passed).