### PR TITLE
fix: require fill or outline on shape primitives

### DIFF
--- a/imgviz/draw/_circle.py
+++ b/imgviz/draw/_circle.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_fill_or_outline
 
 
 def circle(
@@ -59,6 +60,8 @@ def circle_(
         outline: RGB color to draw the outline.
         width: Line width.
     """
+    require_fill_or_outline(fill, outline)
+
     draw = PIL.ImageDraw.Draw(image)
 
     cy, cx = center

--- a/imgviz/draw/_ellipse.py
+++ b/imgviz/draw/_ellipse.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_fill_or_outline
 
 
 def ellipse(
@@ -52,6 +53,8 @@ def ellipse_(
         outline: RGB color to draw the outline.
         width: Line width.
     """
+    require_fill_or_outline(fill, outline)
+
     draw = PIL.ImageDraw.Draw(image)
 
     y1, x1 = yx1

--- a/imgviz/draw/_ink.py
+++ b/imgviz/draw/_ink.py
@@ -22,3 +22,8 @@ def get_pil_ink(
             tuple(int(c) for c in ink.tolist()),
         )
     return ink
+
+
+def require_fill_or_outline(fill: Ink | None, outline: Ink | None) -> None:
+    if fill is None and outline is None:
+        raise ValueError("at least one of `fill` or `outline` must be set")

--- a/imgviz/draw/_rectangle.py
+++ b/imgviz/draw/_rectangle.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_fill_or_outline
 
 
 def rectangle(
@@ -59,6 +60,8 @@ def rectangle_(
         outline: RGB color to draw the outline.
         width: Rectangle line width.
     """
+    require_fill_or_outline(fill, outline)
+
     draw = PIL.ImageDraw.Draw(image)
 
     y1, x1 = map(float, yx1)

--- a/imgviz/draw/_star.py
+++ b/imgviz/draw/_star.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_fill_or_outline
 
 
 def star(
@@ -59,6 +60,8 @@ def star_(
         outline: RGB color to draw the outline.
         width: Line width.
     """
+    require_fill_or_outline(fill, outline)
+
     draw = PIL.ImageDraw.Draw(image)
 
     radius = size / 2

--- a/imgviz/draw/_triangle.py
+++ b/imgviz/draw/_triangle.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_fill_or_outline
 
 
 def triangle(
@@ -59,6 +60,8 @@ def triangle_(
         outline: RGB color to draw the outline.
         width: Line width.
     """
+    require_fill_or_outline(fill, outline)
+
     draw = PIL.ImageDraw.Draw(image)
 
     radius = size / 2

--- a/tests/unit/draw/_circle_test.py
+++ b/tests/unit/draw/_circle_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -9,3 +10,9 @@ def test_circle() -> None:
     assert res.shape == img.shape
     assert res.dtype == img.dtype
     assert not np.array_equal(res, img)
+
+
+def test_circle_rejects_missing_fill_and_outline() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):
+        imgviz.draw.circle(img, center=(50, 50), diameter=30)

--- a/tests/unit/draw/_ellipse_test.py
+++ b/tests/unit/draw/_ellipse_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -9,3 +10,9 @@ def test_ellipse() -> None:
     assert res.shape == img.shape
     assert res.dtype == img.dtype
     assert not np.array_equal(res, img)
+
+
+def test_ellipse_rejects_missing_fill_and_outline() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):
+        imgviz.draw.ellipse(img, yx1=(20, 20), yx2=(80, 60))

--- a/tests/unit/draw/_rectangle_test.py
+++ b/tests/unit/draw/_rectangle_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -8,3 +9,9 @@ def test_rectangle() -> None:
     res = imgviz.draw.rectangle(img, (0, 0), (50, 50), outline=(0, 0, 0))
     assert res.shape == img.shape
     assert res.dtype == img.dtype
+
+
+def test_rectangle_rejects_missing_fill_and_outline() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):
+        imgviz.draw.rectangle(img, (0, 0), (50, 50))

--- a/tests/unit/draw/_star_test.py
+++ b/tests/unit/draw/_star_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -9,3 +10,9 @@ def test_star() -> None:
     assert res.shape == img.shape
     assert res.dtype == img.dtype
     assert not np.array_equal(res, img)
+
+
+def test_star_rejects_missing_fill_and_outline() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):
+        imgviz.draw.star(img, center=(50, 50), size=20)

--- a/tests/unit/draw/_triangle_test.py
+++ b/tests/unit/draw/_triangle_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -9,3 +10,9 @@ def test_triangle() -> None:
     assert res.shape == img.shape
     assert res.dtype == img.dtype
     assert not np.array_equal(res, img)
+
+
+def test_triangle_rejects_missing_fill_and_outline() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):
+        imgviz.draw.triangle(img, center=(50, 50), size=20)


### PR DESCRIPTION
## Summary
- Add `require_fill_or_outline` helper in `_ink.py`
- Call it from `circle_`, `ellipse_`, `rectangle_`, `star_`, and `triangle_`

## Why
Previously, calling these primitives with both `fill` and `outline` unset was a silent no-op: PIL skips drawing without raising, so callers got back an unmodified image with no signal.

## Test plan
- [x] `uv run pytest`
- [x] `uv run ruff check`