### PR TITLE
fix(io): close file handle in imread

### DIFF
--- a/imgviz/io.py
+++ b/imgviz/io.py
@@ -17,7 +17,8 @@ def imread(filename: str | pathlib.Path) -> NDArray[np.uint8]:
     Returns:
         Image with shape (H, W) or (H, W, 3) or (H, W, 4).
     """
-    return _utils.pillow_to_numpy(PIL.Image.open(filename))
+    with PIL.Image.open(filename) as image:
+        return _utils.pillow_to_numpy(image)
 
 
 def imsave(filename: str | pathlib.Path, arr: NDArray[np.uint8]) -> None:


### PR DESCRIPTION
## Summary
- Wrap `PIL.Image.open` in a `with`-block in `imgviz.io.imread` so the file descriptor is released deterministically.

## Why
`PIL.Image.open` keeps the underlying file handle open until the image is fully loaded or the object is garbage-collected. The previous one-liner relied on refcounted GC (CPython) to close the fd, which is a latent leak on PyPy or any future runtime without refcounting. The `with`-block makes the lifetime explicit.

## Test plan
- [x] `pytest tests/unit/io_test.py` passes
- [x] `imgviz.data.lena()` and `imgviz.data.middlebury()` (both call `imread`) still load correctly