### PR TITLE
build(deps): add mdformat-gfm for aligned table formatting

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -184,16 +184,16 @@ Would be a deliberate, breaking change reserved for a future major version.
 These came up during brainstorming but are explicitly out of scope or
 redundant. Recorded here to save future discussions.
 
-| Idea | Why dropped |
-|---|---|
-| COCO / YOLO / Pascal VOC / LabelMe parsers | Application layer. Thin adapters belong downstream. |
+| Idea                                               | Why dropped                                                                       |
+| -------------------------------------------------- | --------------------------------------------------------------------------------- |
+| COCO / YOLO / Pascal VOC / LabelMe parsers         | Application layer. Thin adapters belong downstream.                               |
 | Keypoint schemas (COCO-17, MediaPipe-33, Halpe-26) | Application layer. The primitive takes points and edges; users supply the schema. |
-| PyTorch / JAX / HuggingFace tensor interop | Application layer. Users convert at the boundary. |
-| `compare()`, `tile_annotated()` | Trivially composable from existing `tile` and `text`. |
-| `overlay()` as a separate function | Subsumed by `blend(mode="normal", alpha=...)`. |
-| `border()` | Redundant with `pad` at equal sides. |
-| 3D box projection, BEV canvas | Application layer. Belongs in AV or point-cloud tooling. |
-| GradCAM / SAM / attention-map helpers | Compose from `blend` and mask primitives; no model-specific code in `imgviz`. |
+| PyTorch / JAX / HuggingFace tensor interop         | Application layer. Users convert at the boundary.                                 |
+| `compare()`, `tile_annotated()`                    | Trivially composable from existing `tile` and `text`.                             |
+| `overlay()` as a separate function                 | Subsumed by `blend(mode="normal", alpha=...)`.                                    |
+| `border()`                                         | Redundant with `pad` at equal sides.                                              |
+| 3D box projection, BEV canvas                      | Application layer. Belongs in AV or point-cloud tooling.                          |
+| GradCAM / SAM / attention-map helpers              | Compose from `blend` and mask primitives; no model-specific code in `imgviz`.     |
 
 ## Proposing a new idea
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "ipython>=8.37.0",
   "matplotlib>=3.5.0",
   "mdformat>=1.0.0",
+  "mdformat-gfm>=1.0.0",
   "opencv-python>=4.11.0.86",
   "pytest>=8.4.2",
   "pytest-xdist>=3.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -626,6 +626,7 @@ dev = [
     { name = "ipython", version = "9.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "matplotlib" },
     { name = "mdformat" },
+    { name = "mdformat-gfm" },
     { name = "opencv-python" },
     { name = "pytest" },
     { name = "pytest-xdist" },
@@ -654,6 +655,7 @@ dev = [
     { name = "ipython", specifier = ">=8.37.0" },
     { name = "matplotlib", specifier = ">=3.5.0" },
     { name = "mdformat", specifier = ">=1.0.0" },
+    { name = "mdformat-gfm", specifier = ">=1.0.0" },
     { name = "opencv-python", specifier = ">=4.11.0.86" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
@@ -1099,6 +1101,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
+]
+
+[[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `mdformat-gfm>=1.0.0` to dev dependencies so `mdformat` pads GFM tables.
- Reflow the ROADMAP.md table to the aligned form the plugin produces, so `make lint` stays clean.

## Test plan
- [x] `make lint` passes locally