### PR TITLE
chore(make): use --extra all for format, lint, test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,25 +24,27 @@ help:
 
 PACKAGE_NAME := imgviz
 
+UV_RUN := uv run --extra all
+
 setup:  # Setup dev env
 	$(call exec,uv sync --extra all)
 
 format:  # Format code
-	$(call exec,uv run ruff format)
-	$(call exec,uv run ruff check --fix)
-	$(call exec,uv run taplo fmt $(shell git ls-files "*.toml"))
-	$(call exec,uv run mdformat $(shell git ls-files "*.md"))
-	$(call exec,uv run yamlfix $(shell git ls-files "*.yml" "*.yaml"))
-	$(call exec,uv run typos --write-changes)
+	$(call exec,$(UV_RUN) ruff format)
+	$(call exec,$(UV_RUN) ruff check --fix)
+	$(call exec,$(UV_RUN) taplo fmt $(shell git ls-files "*.toml"))
+	$(call exec,$(UV_RUN) mdformat $(shell git ls-files "*.md"))
+	$(call exec,$(UV_RUN) yamlfix $(shell git ls-files "*.yml" "*.yaml"))
+	$(call exec,$(UV_RUN) typos --write-changes)
 
 lint:  # Check code
-	$(call exec,uv run ruff format --check)
-	$(call exec,uv run ruff check)
-	$(call exec,uv run ty check --no-progress)
-	$(call exec,uv run taplo fmt --check $(shell git ls-files "*.toml"))
-	$(call exec,uv run mdformat --check $(shell git ls-files "*.md"))
-	$(call exec,uv run yamlfix --check $(shell git ls-files "*.yml" "*.yaml"))
-	$(call exec,uv run typos)
+	$(call exec,$(UV_RUN) ruff format --check)
+	$(call exec,$(UV_RUN) ruff check)
+	$(call exec,$(UV_RUN) ty check --no-progress)
+	$(call exec,$(UV_RUN) taplo fmt --check $(shell git ls-files "*.toml"))
+	$(call exec,$(UV_RUN) mdformat --check $(shell git ls-files "*.md"))
+	$(call exec,$(UV_RUN) yamlfix --check $(shell git ls-files "*.yml" "*.yaml"))
+	$(call exec,$(UV_RUN) typos)
 
 test:
-	$(call exec,uv run pytest -n=auto -v tests)
+	$(call exec,$(UV_RUN) pytest -n=auto -v tests)


### PR DESCRIPTION
## Summary
- Introduce `UV_RUN := uv run --extra all` and use it across `format`, `lint`, `test`.
- Ensures the `all` extra (scikit-image, scikit-learn) is present when running tests and linters, so functions like `instances2rgb`/`nchannel2rgb` are exercised.

## Why
`uv run` only auto-syncs base + `[dependency-groups]`; `[project.optional-dependencies]` are not included by default. Passing `--extra all` per invocation lets uv handle the sync on demand without a separate `setup` prerequisite.

## Test plan
- [x] `make lint` passes locally