### PR TITLE
fix: keep normalize min/max distinct after float32 cast

### DIFF
--- a/imgviz/_normalize.py
+++ b/imgviz/_normalize.py
@@ -69,10 +69,13 @@ def normalize(
     if np.isinf(min_value).any() or np.isinf(max_value).any():
         warnings.warn("some of min or max values are inf.")
 
-    eps = np.finfo(image.dtype).eps
+    # Spread proportional to magnitude so the subtraction survives float32
+    # rounding even when min_value is large.
+    eps = np.finfo(min_value.dtype).eps
     issame = max_value == min_value
-    min_value[issame] -= eps
-    max_value[issame] += eps
+    spread = eps * np.maximum(np.abs(min_value[issame]), 1.0)
+    min_value[issame] -= spread
+    max_value[issame] += spread
 
     dst: NDArray[np.float32] = np.zeros(image.shape, dtype=np.float32)
 

--- a/tests/unit/_normalize_test.py
+++ b/tests/unit/_normalize_test.py
@@ -19,3 +19,14 @@ def test_normalize_return_minmax() -> None:
     assert max_val.shape == (1,)
     assert min_val[0] == 0.0
     assert max_val[0] == 100.0
+
+
+def test_normalize_constant_large_float32_is_finite() -> None:
+    # When min == max and the value is large enough that float32 eps rounds
+    # away, the issame spread must remain large enough to survive the cast.
+    src = np.full((4, 4), 1e6, dtype=np.float32)
+
+    result = imgviz.normalize(src)
+
+    assert result.shape == src.shape
+    assert np.isfinite(result).all()


### PR DESCRIPTION
## Summary

`normalize` collapsed `max_value == min_value` to NaN when the shared value was large enough that `float32` eps rounded the issame spread away (e.g. `np.full((4,4), 1e6, dtype=np.float32)`).

Make the spread proportional to magnitude (`eps * max(|min_value|, 1)`) and source eps from `min_value.dtype` (always float32) instead of `image.dtype` (which would raise on integer inputs).

## Test plan
- [x] New regression test: `test_normalize_constant_large_float32_is_finite`
- [x] `uv run pytest tests/`