### PR TITLE
docs: record visualization-construction layer architecture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,26 @@
+# imgviz
+
+A programmatic compositor for scientific and technical imagery: build a final
+image from layered visual pieces, as pure operations on NumPy arrays and PIL
+images.
+
+## Language
+
+### Visualization-construction stack
+
+**Primitive**:
+A single atomic drawing operation that places one shape or mark on an image,
+knowing nothing about what the data means. A circle, a line, a pie.
+_Avoid_: shape, glyph, mark
+
+**Component**:
+A reusable visual assembled from primitives plus layout, still knowing nothing
+about data semantics: it receives already-resolved colors and text, not domain
+data. A legend, a colorbar.
+_Avoid_: widget, element, part
+
+**Composition**:
+An end-to-end function that turns domain data into a finished visualization,
+applying the data's semantics and assembling primitives and components to do it.
+`label2rgb`, `instances2rgb`, `mask2rgb`.
+_Avoid_: visualizer, recipe, "2rgb function"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,8 +156,25 @@ fill semantics and dtype handling live in one place.
 
 ## Structural changes under consideration
 
-These are larger shifts that affect the public API. Neither is committed;
+These are larger shifts that affect the public API. None of these is committed;
 each would start as a prototype in `examples/` before any core change.
+
+### Visualization-construction layers
+
+A three-layer model for the drawing/visualization surface, recorded in
+`docs/adr/0001-visualization-construction-layers.md`:
+
+- **Primitives** (`imgviz.draw`) — atomic, semantics-free draw ops.
+- **Components** (`imgviz.components`) — reusable composites of primitives plus
+  layout, still semantics-free, e.g. `legend` (extracted from the in-image
+  legend currently inside `label2rgb`).
+- **Compositions** — flat top-level verbs that bind domain data to primitives
+  and components (`label2rgb`, `instances2rgb`, `mask2rgb`).
+
+The rule: building blocks you assemble get a namespace; end-product verbs you
+call stay flat. `draw` and `io` keep their names; color and dtype conversions
+stay flat for backward compatibility and convenience. Any wider namespace reorg
+is a major-version move behind back-compat aliases, not an incremental change.
 
 ### `Layer` + `compose()`
 

--- a/docs/adr/0001-visualization-construction-layers.md
+++ b/docs/adr/0001-visualization-construction-layers.md
@@ -1,0 +1,44 @@
+# Visualization-construction layers and namespace placement
+
+Status: accepted
+
+We organize imgviz's drawing and visualization surface into three layers and
+place them by one rule: a building block you assemble gets a namespace; an
+end-product verb you call stays flat at the top level.
+
+- **Primitives** — `imgviz.draw.*`: one atomic draw op, semantics-free
+  (`circle`, `polygon`, `pie`).
+- **Components** — `imgviz.components.*`: reusable composites of primitives plus
+  layout, still semantics-free (`legend`, `text_in_rectangle`).
+- **Compositions** — flat top-level verbs that turn domain data into a finished
+  visualization (`label2rgb`, `instances2rgb`, `mask2rgb`, `colorize`).
+
+`draw` and `io` keep their verb-shaped names: both have direct precedent
+(`skimage.draw` / `skimage.io`, `PIL.ImageDraw`) and read as domain nouns.
+
+Color and dtype conversions (`gray2rgb`, `bool2ubyte`, ...) stay flat at the top
+level for backward compatibility and call-site convenience. They are boundary
+adapters, not assembly pieces, so the building-block rule does not pull them into
+a namespace. If they are ever grouped, the namespace is `color` (matching
+`skimage.color`), never the bare verb `convert`.
+
+## Considered and rejected
+
+- **Fold components into `draw`** (the way scikit-image houses everything
+  drawable in one module). Rejected: it collapses the primitive/component
+  distinction this ADR exists to draw.
+- **A `components` name with imaging-domain precedent.** There is none: no NumPy
+  imaging library has a reusable semantics-free composite tier, because none aim
+  to be a layered compositor. We accept the borrowed term over forcing a worse
+  imaging-native noun.
+- **Namespacing conversions now** (e.g. `imgviz.color.gray2rgb`). Deferred:
+  churn on the most-called functions for little gain; revisit only as part of a
+  major-version reorg behind back-compat aliases.
+
+## Consequences
+
+The top level is intentionally a hybrid: flat end-product verbs alongside
+namespaced building blocks. This diverges from scikit-image's uniformly
+namespaced submodules (it is closer to OpenCV's flat surface), trading a small
+discoverability cost (users must learn which names are flat) for call-site
+brevity. The hybrid rule must be documented prominently.


### PR DESCRIPTION
Records the visualization-construction layer architecture worked out while
reviewing the `pie` proposal (#146). No code changes — this captures the
vocabulary and the decision so the same discussion does not restart.

The model: three layers on the drawing/visualization surface —
- **Primitives** (`imgviz.draw`) — atomic, semantics-free draw ops
- **Components** (`imgviz.components`) — reusable composites of primitives plus layout, still semantics-free (e.g. `legend`)
- **Compositions** — flat top-level `*2rgb` verbs that bind domain data

The rule: a building block you assemble gets a namespace; an end-product verb
you call stays flat. `draw`/`io` keep their names; color/dtype conversions stay
flat for back-compat and convenience.

Files:
- `CONTEXT.md` — glossary (Primitive / Component / Composition)
- `docs/adr/0001-visualization-construction-layers.md` — the decision, rejected alternatives, consequences
- `ROADMAP.md` — entry under "Structural changes under consideration"
