### PR TITLE
feat: add directional multi-channel imgviz.pad

### DIFF
--- a/imgviz/__init__.py
+++ b/imgviz/__init__.py
@@ -37,6 +37,7 @@ from ._masks import mask2rgb
 from ._nchannel import Nchannel2Rgb
 from ._nchannel import nchannel2rgb
 from ._normalize import normalize
+from ._pad import pad
 from ._pixelate import pixelate
 from ._resize import resize
 from ._tile import tile

--- a/imgviz/_letterbox.py
+++ b/imgviz/_letterbox.py
@@ -7,6 +7,7 @@ from typing import Literal
 import numpy as np
 from numpy.typing import NDArray
 
+from ._pad import pad
 from ._resize import resize
 
 
@@ -68,43 +69,49 @@ def letterbox(
         else:
             return image
 
-    dst = np.zeros(shape, dtype=image.dtype)
-    if color is not None:
-        dst[:, :] = color
-
     image_h, image_w = image.shape[:2]
-    scale_h, scale_w = 1.0 * shape[0] / image_h, 1.0 * shape[1] / image_w
-    scale = min(scale_h, scale_w)
-    dst_h, dst_w = int(round(image_h * scale)), int(round(image_w * scale))
-    image = resize(image, height=dst_h, width=dst_w, interpolation=interpolation)
+    scale = min(1.0 * height / image_h, 1.0 * width / image_w)
+    image = resize(
+        image,
+        height=int(round(image_h * scale)),
+        width=int(round(image_w * scale)),
+        interpolation=interpolation,
+    )
 
     ph, pw = 0, 0
     h, w = image.shape[:2]
-    dst_h, dst_w = shape[:2]
     if loc == "center":
-        if h < dst_h:
-            ph = (dst_h - h) // 2
-        if w < dst_w:
-            pw = (dst_w - w) // 2
+        if h < height:
+            ph = (height - h) // 2
+        if w < width:
+            pw = (width - w) // 2
     elif loc == "lt":
         ph = 0
         pw = 0
     elif loc == "rt":
         ph = 0
-        if w < dst_w:
-            pw = dst_w - w
+        if w < width:
+            pw = width - w
     elif loc == "lb":
-        if h < dst_h:
-            ph = dst_h - h
+        if h < height:
+            ph = height - h
         pw = 0
     elif loc == "rb":
-        if h < dst_h:
-            ph = dst_h - h
-        if w < dst_w:
-            pw = dst_w - w
+        if h < height:
+            ph = height - h
+        if w < width:
+            pw = width - w
     else:
         raise ValueError(f"unsupported loc: {loc}")
-    dst[ph : ph + h, pw : pw + w] = image
+
+    dst = pad(
+        image,
+        top=ph,
+        bottom=height - h - ph,
+        left=pw,
+        right=width - w - pw,
+        color=0 if color is None else color,
+    )
 
     if return_mask:
         mask = np.zeros(shape[:2], dtype=bool)

--- a/imgviz/_pad.py
+++ b/imgviz/_pad.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import numbers
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+Color: TypeAlias = int | float | tuple[int | float, ...] | NDArray
+
+
+def pad(
+    image: NDArray,
+    top: int = 0,
+    bottom: int = 0,
+    left: int = 0,
+    right: int = 0,
+    color: Color = 0,
+) -> NDArray:
+    """Pad an image with a constant color on each side.
+
+    Handles ``HW`` and ``HWC`` layouts (including RGBA) and preserves dtype, so
+    it replaces ``np.pad(img, ((t, b), (l, r), (0, 0)), constant_values=...)``.
+
+    Args:
+        image: Image to pad, with shape (H, W) or (H, W, C).
+        top: Pixels to add above the image.
+        bottom: Pixels to add below the image.
+        left: Pixels to add to the left of the image.
+        right: Pixels to add to the right of the image.
+        color: Fill color for the added border. A scalar fills every channel; a
+            tuple or array fills per channel and must match the channel count.
+
+    Returns:
+        A new padded image with the same dtype as the input.
+
+    Example:
+        >>> import imgviz
+        >>> image = imgviz.data.arc2017()["rgb"]
+        >>> framed = imgviz.pad(image, top=8, bottom=8, left=8, right=8)
+        >>> banner = imgviz.pad(image, top=40, color=(0, 0, 0))
+    """
+    if image.ndim not in (2, 3):
+        raise ValueError(f"image.ndim must be 2 or 3, but got {image.ndim}")
+
+    for name, value in (
+        ("top", top),
+        ("bottom", bottom),
+        ("left", left),
+        ("right", right),
+    ):
+        if not isinstance(value, numbers.Integral):
+            raise TypeError(f"{name} must be int, but got {type(value).__name__}")
+        if value < 0:
+            raise ValueError(f"{name} must be >= 0, but got {value}")
+
+    components = np.asarray(color)
+    if components.ndim > 0:
+        if image.ndim == 2:
+            raise ValueError(
+                f"color has {components.size} components but a single-channel "
+                "(H, W) image takes a scalar color"
+            )
+        if components.size != image.shape[2]:
+            raise ValueError(
+                f"color has {components.size} components but image has "
+                f"{image.shape[2]} channels"
+            )
+
+    h, w = image.shape[:2]
+    shape = (h + top + bottom, w + left + right) + image.shape[2:]
+    dst = np.empty(shape, dtype=image.dtype)
+    dst[...] = color
+    dst[top : top + h, left : left + w] = image
+    return dst

--- a/tests/unit/_pad_test.py
+++ b/tests/unit/_pad_test.py
@@ -1,0 +1,111 @@
+import numpy as np
+import pytest
+
+import imgviz
+
+
+def test_pad_hw_grayscale() -> None:
+    image = np.random.randint(0, 256, size=(10, 20), dtype=np.uint8)
+
+    dst = imgviz.pad(image, top=2, bottom=3, left=4, right=5, color=0)
+
+    assert dst.shape == (15, 29)
+    assert dst.dtype == image.dtype
+    np.testing.assert_array_equal(dst[2:12, 4:24], image)
+    assert (dst[:2] == 0).all()
+    assert (dst[-3:] == 0).all()
+    assert (dst[:, :4] == 0).all()
+    assert (dst[:, -5:] == 0).all()
+
+
+def test_pad_hwc_rgb() -> None:
+    image = np.random.randint(0, 256, size=(8, 8, 3), dtype=np.uint8)
+
+    dst = imgviz.pad(image, top=1, bottom=1, left=1, right=1, color=(10, 20, 30))
+
+    assert dst.shape == (10, 10, 3)
+    np.testing.assert_array_equal(dst[1:9, 1:9], image)
+    np.testing.assert_array_equal(dst[0, 0], [10, 20, 30])
+    np.testing.assert_array_equal(dst[-1, -1], [10, 20, 30])
+
+
+def test_pad_hwca_rgba() -> None:
+    image = np.random.randint(0, 256, size=(8, 8, 4), dtype=np.uint8)
+
+    dst = imgviz.pad(image, top=2, color=(0, 0, 0, 255))
+
+    assert dst.shape == (10, 8, 4)
+    np.testing.assert_array_equal(dst[2:], image)
+    assert (dst[:2, :, 3] == 255).all()
+
+
+def test_pad_directional_only_one_side() -> None:
+    image = np.full((4, 4, 3), 7, dtype=np.uint8)
+
+    dst = imgviz.pad(image, right=3, color=0)
+
+    assert dst.shape == (4, 7, 3)
+    np.testing.assert_array_equal(dst[:, :4], image)
+    assert (dst[:, 4:] == 0).all()
+
+
+def test_pad_scalar_color_fills_every_channel() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    dst = imgviz.pad(image, top=1, color=255)
+
+    np.testing.assert_array_equal(dst[0], np.full((4, 3), 255, dtype=np.uint8))
+
+
+def test_pad_color_ndarray() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    dst = imgviz.pad(image, left=1, color=np.array([1, 2, 3], dtype=np.uint8))
+
+    np.testing.assert_array_equal(dst[:, 0], np.tile([1, 2, 3], (4, 1)))
+
+
+def test_pad_zero_on_all_sides_returns_equal_array() -> None:
+    image = np.random.randint(0, 256, size=(5, 6, 3), dtype=np.uint8)
+
+    dst = imgviz.pad(image)
+
+    assert dst is not image
+    np.testing.assert_array_equal(dst, image)
+
+
+def test_pad_preserves_float_dtype() -> None:
+    image = np.random.rand(4, 4).astype(np.float32)
+
+    dst = imgviz.pad(image, top=1, color=0.5)
+
+    assert dst.dtype == np.float32
+    assert (dst[0] == np.float32(0.5)).all()
+
+
+def test_pad_negative_border_raises() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="top must be >= 0"):
+        imgviz.pad(image, top=-1)
+
+
+def test_pad_invalid_ndim_raises() -> None:
+    image = np.zeros((4,), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="image.ndim must be 2 or 3"):
+        imgviz.pad(image, top=1)
+
+
+def test_pad_tuple_color_on_grayscale_raises() -> None:
+    image = np.zeros((4, 4), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="single-channel"):
+        imgviz.pad(image, top=1, color=(0, 0, 0))
+
+
+def test_pad_color_channel_mismatch_raises() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="color has 4 components but image has 3"):
+        imgviz.pad(image, top=1, color=(0, 0, 0, 255))


### PR DESCRIPTION
## Summary
- Add `imgviz.pad(image, top=0, bottom=0, left=0, right=0, color=0)` — a directional, multi-channel, dtype-aware padding primitive that replaces awkward `np.pad(img, ((t,b),(l,r),(0,0)), constant_values=...)` calls.
- Handles `HW` and `HWC` layouts (including RGBA); `color` accepts a scalar (fills every channel) or a per-channel tuple/array, validated against the channel count with a clear error. Preserves dtype and always returns a new array (ADR 0002: immutable by default).
- Refactor `letterbox` to delegate its fill and placement to `pad`, so fill semantics and dtype handling live in one place (ADR 0002 principle 2).

## Scope notes
- Argument order `top/bottom/left/right` + `color` matches `cv2.copyMakeBorder` and imgviz's existing `color=` convention (`letterbox`, `draw`).
- Equal-sides padding is `pad(top=N, bottom=N, left=N, right=N)`, which is exactly why ADR 0002 rejects a separate `border()` ("redundant with `pad` at equal sides"). No scalar shorthand added, to avoid premature parameterization.
- `tile`'s `border` is an interior gap between tiles (not outer padding) and `draw._text_in_rectangle`'s `np.pad` is RGB-only with coupled coordinate shifts — both left out of scope. `centerize` is already a deprecation shim over `letterbox`, so it inherits the delegation for free.

## Test plan
- [x] tests added: `tests/unit/_pad_test.py` (HW/HWC/RGBA, directional asymmetry, scalar/tuple/ndarray color, copy contract, float dtype, validation errors)
- [x] `uv run pytest tests/unit/_pad_test.py tests/unit/_letterbox_test.py tests/unit/_tile_test.py tests/unit/_centerize_test.py` — 54 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` clean on touched files

Closes #159
