### PR TITLE
refactor: extract corner legend into imgviz.components.legend

### DIFF
--- a/imgviz/__init__.py
+++ b/imgviz/__init__.py
@@ -2,6 +2,7 @@ import importlib.metadata
 
 __version__ = importlib.metadata.version("imgviz")
 
+from . import components
 from . import data
 from . import draw
 from . import fill

--- a/imgviz/_label.py
+++ b/imgviz/_label.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 
 from . import _color
 from . import _utils
+from . import components
 from . import draw as draw_module
 
 
@@ -146,60 +147,12 @@ def label2rgb(
                 size=font_size,
                 font_path=font_path,
             )
-    elif loc in ["rb", "lt", "rt", "lb"]:
-        text_sizes = np.array(
-            [
-                draw_module.text_size(
-                    label_names[label_id], font_size, font_path=font_path
-                )
-                for label_id in unique_labels
-            ]
-        )
-        text_height, text_width = text_sizes.max(axis=0)
-        pad: int = max(2, font_size // 6)
-        legend_height = text_height * len(unique_labels) + pad
-        legend_width = text_width + text_height + 2 * pad
+        return _utils.pillow_to_numpy(res)
 
-        height, width = label.shape[:2]
-        if loc == "rb":
-            yx2 = np.array([height - pad, width - pad], dtype=float)
-            yx1 = yx2 - (legend_height, legend_width)
-        elif loc == "lt":
-            yx1 = np.array([pad, pad], dtype=float)
-            yx2 = yx1 + (legend_height, legend_width)
-        elif loc == "rt":
-            yx1 = np.array([pad, width - pad - legend_width], dtype=float)
-            yx2 = yx1 + (legend_height, legend_width)
-        elif loc == "lb":
-            yx2 = np.array([height - pad, pad + legend_width], dtype=float)
-            yx1 = yx2 - (legend_height, legend_width)
-        else:
-            raise ValueError(f"unsupported loc: {loc}")
-
-        alpha = 0.5
-        y1, x1 = yx1.round().astype(int)
-        y2, x2 = yx2.round().astype(int)
-        res[y1:y2, x1:x2] = alpha * res[y1:y2, x1:x2] + alpha * 255
-
-        box_size = text_height - 2 * pad
-        res = _utils.numpy_to_pillow(res)
-        for i, label_id in enumerate(unique_labels):
-            box_yx1 = yx1 + (i * text_height + pad, pad)
-            box_yx2 = box_yx1 + (box_size, box_size)
-            draw_module.rectangle_(
-                res, yx1=box_yx1, yx2=box_yx2, fill=colormap[label_id]
-            )
-            draw_module.text_(
-                res,
-                yx=yx1 + (i * text_height, text_height),
-                text=label_names[label_id],
-                size=font_size,
-                font_path=font_path,
-            )
-    else:
-        raise ValueError(f"unsupported loc: {loc}")
-
-    return _utils.pillow_to_numpy(res)
+    items = [(label_names[label_id], colormap[label_id]) for label_id in unique_labels]
+    return components.legend(
+        res, items=items, font_size=font_size, font_path=font_path, loc=loc
+    )
 
 
 def _center_of_mass(mask: NDArray[np.bool_]) -> tuple[float, float]:

--- a/imgviz/components/__init__.py
+++ b/imgviz/components/__init__.py
@@ -1,0 +1,3 @@
+from ._legend import LegendItem
+from ._legend import legend
+from ._legend import legend_

--- a/imgviz/components/_legend.py
+++ b/imgviz/components/_legend.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal
+from typing import TypeAlias
+
+import numpy as np
+import PIL.Image
+from numpy.typing import NDArray
+
+from .. import _utils
+from .. import draw as draw_module
+from ..draw import Ink
+
+LegendItem: TypeAlias = tuple[str, Ink]
+
+
+def legend(
+    image: NDArray[np.uint8],
+    items: Sequence[LegendItem],
+    font_size: int = 25,
+    font_path: str | None = None,
+    loc: Literal["lt", "rt", "lb", "rb"] = "rb",
+) -> NDArray[np.uint8]:
+    """Draw a corner legend of colored boxes with text labels.
+
+    Args:
+        image: Input image with shape (H, W, 3).
+        items: Resolved (text, color) pairs, one per legend row. If empty, the
+            image is returned unchanged.
+        font_size: Font size.
+        font_path: Font path.
+        loc: Corner to place the legend ('lt', 'rt', 'lb', 'rb').
+
+    Returns:
+        Output image.
+    """
+    dst = _utils.numpy_to_pillow(image)
+    legend_(
+        image=dst,
+        items=items,
+        font_size=font_size,
+        font_path=font_path,
+        loc=loc,
+    )
+    return _utils.pillow_to_numpy(dst)
+
+
+def legend_(
+    image: PIL.Image.Image,
+    items: Sequence[LegendItem],
+    font_size: int = 25,
+    font_path: str | None = None,
+    loc: Literal["lt", "rt", "lb", "rb"] = "rb",
+) -> None:
+    """Draw a corner legend on a PIL image in-place.
+
+    Args:
+        image: PIL image to draw on (modified in-place).
+        items: Resolved (text, color) pairs, one per legend row. If empty, this
+            is a no-op.
+        font_size: Font size.
+        font_path: Font path.
+        loc: Corner to place the legend ('lt', 'rt', 'lb', 'rb').
+    """
+    if len(items) == 0:
+        return
+
+    text_sizes = np.array(
+        [
+            draw_module.text_size(text, font_size, font_path=font_path)
+            for text, _ in items
+        ]
+    )
+    text_height, text_width = text_sizes.max(axis=0)
+    pad: int = max(2, font_size // 6)
+    legend_height = text_height * len(items) + pad
+    legend_width = text_width + text_height + 2 * pad
+
+    width, height = image.size
+    if loc == "rb":
+        yx2 = np.array([height - pad, width - pad], dtype=float)
+        yx1 = yx2 - (legend_height, legend_width)
+    elif loc == "lt":
+        yx1 = np.array([pad, pad], dtype=float)
+        yx2 = yx1 + (legend_height, legend_width)
+    elif loc == "rt":
+        yx1 = np.array([pad, width - pad - legend_width], dtype=float)
+        yx2 = yx1 + (legend_height, legend_width)
+    elif loc == "lb":
+        yx2 = np.array([height - pad, pad + legend_width], dtype=float)
+        yx1 = yx2 - (legend_height, legend_width)
+    else:
+        raise ValueError(f"unsupported loc: {loc}")
+
+    alpha = 0.5
+    y1, x1 = yx1.round().astype(int)
+    y2, x2 = yx2.round().astype(int)
+    region = np.asarray(image)[y1:y2, x1:x2]
+    washed = (alpha * region + alpha * 255).astype(np.uint8)
+    image.paste(_utils.numpy_to_pillow(washed), (int(x1), int(y1)))
+
+    box_size = text_height - 2 * pad
+    for i, (text, color) in enumerate(items):
+        box_yx1 = yx1 + (i * text_height + pad, pad)
+        box_yx2 = box_yx1 + (box_size, box_size)
+        draw_module.rectangle_(image, yx1=box_yx1, yx2=box_yx2, fill=color)
+        draw_module.text_(
+            image,
+            yx=yx1 + (i * text_height, text_height),
+            text=text,
+            size=font_size,
+            font_path=font_path,
+        )

--- a/tests/unit/components/_legend_test.py
+++ b/tests/unit/components/_legend_test.py
@@ -1,0 +1,51 @@
+from typing import Literal
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+import imgviz
+
+
+@pytest.fixture
+def white_image() -> NDArray[np.uint8]:
+    return np.full((200, 200, 3), 255, dtype=np.uint8)
+
+
+def test_legend_preserves_shape_and_dtype(white_image: NDArray[np.uint8]) -> None:
+    res = imgviz.components.legend(
+        white_image,
+        items=[("cat", (255, 0, 0)), ("dog", (0, 0, 255))],
+    )
+    assert res.shape == white_image.shape
+    assert res.dtype == white_image.dtype
+    assert not np.array_equal(res, white_image)
+
+
+def test_legend_empty_items_is_noop(white_image: NDArray[np.uint8]) -> None:
+    res = imgviz.components.legend(white_image, items=[])
+    assert np.array_equal(res, white_image)
+
+
+@pytest.mark.parametrize(
+    ("loc", "corner"),
+    [
+        ("lt", (slice(0, 100), slice(0, 100))),
+        ("rt", (slice(0, 100), slice(100, 200))),
+        ("lb", (slice(100, 200), slice(0, 100))),
+        ("rb", (slice(100, 200), slice(100, 200))),
+    ],
+)
+def test_legend_loc_places_in_corner(
+    white_image: NDArray[np.uint8],
+    loc: Literal["lt", "rt", "lb", "rb"],
+    corner: tuple[slice, slice],
+) -> None:
+    res = imgviz.components.legend(
+        white_image,
+        items=[("cat", (255, 0, 0))],
+        loc=loc,
+    )
+    non_white = ~(res == 255).all(axis=2)
+    assert non_white.any()
+    assert non_white.sum() == non_white[corner].sum()


### PR DESCRIPTION
## Summary
- Add `imgviz.components`, the first occupant of the components tier from
  `docs/adr/0001-visualization-construction-layers.md` (reusable, semantics-free
  composites of `draw` primitives plus layout).
- Add `components.legend` / `components.legend_`, a functional/in-place pair
  mirroring `draw.pie` / `pie_`. It draws the corner legend (`loc` `lt`/`rt`/`lb`/`rb`)
  from resolved `(text, color)` pairs and carries no data semantics.
- `label2rgb` becomes the first caller: it keeps all data binding (unique labels,
  `thresh_suppress` filtering, colormap lookup) and passes only resolved pairs across
  the boundary. The `loc="centroid"` path stays inline since it is data-bound
  placement, not a legend.

This is a pure refactor: `label2rgb` output is pixel-identical before and after,
verified across all five `loc` values on `imgviz.data.arc2017()`. The legend
background wash (`0.5 * existing + 0.5 * 255`, lightening toward white) is carried
over unchanged.

Closes #161.

## Test plan
- [x] `tests/unit/components/_legend_test.py` added (shape/dtype, empty-items no-op, per-corner placement)
- [x] pixel-identity check: `label2rgb` output byte-for-byte identical for `lt`/`rt`/`lb`/`rb`/`centroid`
- [x] `uv run pytest tests/unit/components tests/unit/_label_test.py`
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check`
