### PR TITLE
fix: avoid ambiguous array comparison in Nchannel2Rgb cache

### DIFF
--- a/imgviz/_nchannel.py
+++ b/imgviz/_nchannel.py
@@ -70,7 +70,7 @@ class Nchannel2Rgb:
         dst = dst.reshape(H, W, 3)
 
         if dtype == np.uint8:
-            if self._min_max_value == (None, None):
+            if self._min_max_value[0] is None:
                 self._min_max_value = (
                     np.nanmin(dst, axis=(0, 1)),
                     np.nanmax(dst, axis=(0, 1)),

--- a/tests/unit/_nchannel_test.py
+++ b/tests/unit/_nchannel_test.py
@@ -1,0 +1,101 @@
+import numpy as np
+import pytest
+import sklearn.decomposition
+from numpy.typing import NDArray
+
+import imgviz
+
+
+@pytest.fixture
+def nchannel() -> NDArray[np.float32]:
+    rng = np.random.RandomState(0)
+    return rng.rand(8, 8, 16).astype(np.float32)
+
+
+def test_nchannel2rgb_returns_uint8_rgb(nchannel: NDArray[np.float32]) -> None:
+    out = imgviz.nchannel2rgb(nchannel)
+
+    assert out.shape == (8, 8, 3)
+    assert out.dtype == np.uint8
+    assert out.max() > out.min()
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_nchannel2rgb_float_dtype(
+    nchannel: NDArray[np.float32], dtype: type[np.floating]
+) -> None:
+    out = imgviz.nchannel2rgb(nchannel, dtype=dtype)
+
+    assert out.shape == (8, 8, 3)
+    assert out.dtype == dtype
+
+
+def test_nchannel2rgb_rejects_invalid_output_dtype(
+    nchannel: NDArray[np.float32],
+) -> None:
+    with pytest.raises(ValueError, match="dtype must be floating"):
+        imgviz.nchannel2rgb(nchannel, dtype=np.int32)  # type: ignore[call-overload]
+
+
+def test_nchannel2rgb_is_deterministic(nchannel: NDArray[np.float32]) -> None:
+    out1 = imgviz.nchannel2rgb(nchannel)
+    out2 = imgviz.nchannel2rgb(nchannel)
+
+    np.testing.assert_array_equal(out1, out2)
+
+
+def test_nchannel2rgb_with_prefit_pca(nchannel: NDArray[np.float32]) -> None:
+    pca = sklearn.decomposition.PCA(n_components=3, random_state=0)
+    pca.fit(nchannel.reshape(-1, nchannel.shape[-1]))
+
+    out = imgviz.nchannel2rgb(nchannel, pca=pca)
+
+    assert out.shape == (8, 8, 3)
+    assert out.dtype == np.uint8
+
+
+def test_Nchannel2Rgb_exposes_pca() -> None:
+    pca = sklearn.decomposition.PCA(n_components=3, random_state=0)
+
+    converter = imgviz.Nchannel2Rgb(pca=pca)
+
+    assert converter.pca is pca
+
+
+def test_Nchannel2Rgb_reuses_cached_range_across_frames(
+    nchannel: NDArray[np.float32],
+) -> None:
+    pca = sklearn.decomposition.PCA(n_components=3, random_state=0)
+    pca.fit(nchannel.reshape(-1, nchannel.shape[-1]))
+
+    converter = imgviz.Nchannel2Rgb(pca=pca)
+    converter(nchannel)
+
+    second_frame = nchannel * 2.0
+    out_reused = converter(second_frame)
+    out_fresh = imgviz.nchannel2rgb(second_frame, pca=pca)
+
+    assert out_reused.shape == (8, 8, 3)
+    assert out_reused.dtype == np.uint8
+    assert not np.array_equal(out_reused, out_fresh)
+
+
+def test_nchannel2rgb_rejects_non_3d() -> None:
+    with pytest.raises(ValueError, match="nchannel.ndim must be 3"):
+        imgviz.nchannel2rgb(np.zeros((4, 4), dtype=np.float32))
+
+
+def test_nchannel2rgb_rejects_non_floating() -> None:
+    with pytest.raises(ValueError, match="nchannel.dtype must be floating"):
+        imgviz.nchannel2rgb(np.zeros((4, 4, 3), dtype=np.uint8))
+
+
+# res4's float32 values overflow in sklearn's PCA matmul; the warning is benign.
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_nchannel2rgb_matches_example() -> None:
+    res4 = imgviz.data.arc2017()["res4"]
+
+    out = imgviz.nchannel2rgb(res4)
+
+    assert out.shape == (*res4.shape[:2], 3)
+    assert out.dtype == np.uint8


### PR DESCRIPTION
Reusing a `Nchannel2Rgb` instance for a second `uint8` call raised
`ValueError: truth value of an array is ambiguous`. Once the min/max cache
held numpy arrays, the guard `self._min_max_value == (None, None)` performed an
element-wise comparison. The stateful cache (the only reason to reuse the class
over the `nchannel2rgb` function, e.g. consistent normalization across frames)
was broken; the function path never hit it and there were no tests.

## Summary
- Fix the guard to `self._min_max_value[0] is None`, matching the sentinel idiom
  in `_normalize.py`. The `nchannel2rgb` function path is unchanged.
- Add `tests/unit/_nchannel_test.py` (the module had zero coverage): uint8 and
  float32/float64 output, determinism, the pre-fit PCA path, the `.pca`
  property, cross-frame cache reuse (the repaired path), the bundled example,
  and input/output dtype + ndim validation.

## Test plan
- [x] `uv run pytest tests/unit/_nchannel_test.py` (11 passed)
- [x] full suite `uv run pytest -n=auto tests` (167 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on changed files
