### PR TITLE
fix: honor copy=True for RGBA input in asrgb

### DIFF
--- a/imgviz/_color.py
+++ b/imgviz/_color.py
@@ -142,7 +142,8 @@ def asrgb(image: NDArray, copy: bool = False) -> NDArray[np.uint8]:
 
     Args:
         image: Input image.
-        copy: Whether to return a copy of the image.
+        copy: Whether to return a copy of the image. When False (the default),
+            the returned array may share memory with the input.
 
     Returns:
         RGB image with shape (H, W, 3).
@@ -154,13 +155,13 @@ def asrgb(image: NDArray, copy: bool = False) -> NDArray[np.uint8]:
     elif image.ndim == 3 and image.shape[2] == 4:
         rgb = rgba2rgb(image)
     elif image.ndim == 3 and image.shape[2] == 3:
-        rgb = image.copy() if copy else image
+        rgb = image
     else:
         raise ValueError(
             f"unsupported image format to convert to rgb: "
             f"shape={image.shape}, dtype={image.dtype}"
         )
-    return rgb
+    return rgb.copy() if copy else rgb
 
 
 def asrgba(image: NDArray) -> NDArray[np.uint8]:

--- a/tests/unit/_color_test.py
+++ b/tests/unit/_color_test.py
@@ -32,6 +32,28 @@ def test_asrgb(images: dict[str, NDArray[np.uint8]]) -> None:
         assert result.shape[2] == 3
 
 
+def test_asrgb_copy_does_not_alias_rgba_input(
+    images: dict[str, NDArray[np.uint8]],
+) -> None:
+    rgba = images["rgba"]
+    original = rgba[:, :, :3].copy()
+
+    rgb = imgviz.asrgb(rgba, copy=True)
+    rgb[:] = 0
+
+    np.testing.assert_array_equal(rgba[:, :, :3], original)
+
+
+def test_asrgb_no_copy_returns_view_for_rgba_input(
+    images: dict[str, NDArray[np.uint8]],
+) -> None:
+    rgba = images["rgba"]
+
+    rgb = imgviz.asrgb(rgba)
+
+    assert np.shares_memory(rgb, rgba)
+
+
 def test_asrgba(images: dict[str, NDArray[np.uint8]]) -> None:
     for img in images.values():
         result = imgviz.asrgba(img)

--- a/tests/unit/_masks_test.py
+++ b/tests/unit/_masks_test.py
@@ -63,6 +63,15 @@ def test_mask2rgb_stripe(show: bool, image: NDArray[np.uint8] | None) -> None:
     assert 0.48 < num_pixels / mask.sum() < 0.52
 
 
+def test_mask2rgb_does_not_mutate_rgba_image() -> None:
+    image: NDArray[np.uint8] = imgviz.rgb2rgba(_WHITE_IMAGE)
+    original = image.copy()
+
+    imgviz.mask2rgb(mask=_SIMPLE_MASK, image=image, fill=_COLOR_RED)
+
+    np.testing.assert_array_equal(image, original)
+
+
 def test_stripe_validation() -> None:
     with pytest.raises(ValueError, match="width must be positive"):
         imgviz.fill.Stripe(color=_COLOR_RED, width=0)


### PR DESCRIPTION
`rgba2rgb` returns a view (`rgba[:, :, :3]`), and `asrgb` only applied `copy`
in its 3-channel branch, so `asrgb(rgba, copy=True)` returned a view. Because
`mask2rgb` calls `asrgb(image, copy=True)` precisely to avoid mutating the
caller before filling in place, passing an RGBA image silently overwrote the
caller's array.

## Summary
- Apply the copy once at `asrgb`'s exit (`return rgb.copy() if copy else rgb`)
  so every input branch honors `copy` uniformly, and document that `copy=False`
  may return a view.
- Regression tests: `asrgb(rgba, copy=True)` returns an independent array,
  `asrgb(rgba)` returns a view, and `mask2rgb` does not mutate an RGBA image.

## Test plan
- [x] `uv run pytest tests/unit/_color_test.py tests/unit/_masks_test.py` (17 passed)
- [x] full suite `uv run pytest -n=auto tests` (175 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on changed files
