### PR TITLE
fix: prevent out-of-bounds color-wheel index in flow2rgb

### DIFF
--- a/imgviz/_flow.py
+++ b/imgviz/_flow.py
@@ -60,9 +60,10 @@ def _flow_compute_color(flow_u: NDArray, flow_v: NDArray) -> NDArray[np.uint8]:
 
     fk = (a + 1) / 2 * (ncols - 1) + 1
     k0 = np.floor(fk).astype(np.int32)
+    f = fk - k0
+    k0[k0 == ncols] = 1  # angle +pi wraps to the wheel start, same as -pi
     k1 = k0 + 1
     k1[k1 == ncols] = 1
-    f = fk - k0
 
     for i in range(colorwheel.shape[1]):
         tmp = colorwheel[:, i]

--- a/tests/unit/_flow_test.py
+++ b/tests/unit/_flow_test.py
@@ -26,3 +26,21 @@ def test_flow2rgb(use_class: bool, show: bool) -> None:
     assert flow_viz.dtype == np.uint8
     H, W = flow.shape[:2]
     assert flow_viz.shape == (H, W, 3)
+
+
+def test_flow2rgb_handles_negative_zero_v() -> None:
+    # A v-component of IEEE negative zero makes arctan2 return +pi, which
+    # pushed the color-wheel index out of bounds. The vector (1, -0.0) is
+    # identical to (1, +0.0), so it must produce the same visualization.
+    flow_neg = np.zeros((4, 4, 2), dtype=np.float32)
+    flow_neg[:, :, 0] = 1.0
+    flow_neg[:, :, 1] = np.float32(-0.0)
+
+    flow_pos = np.zeros((4, 4, 2), dtype=np.float32)
+    flow_pos[:, :, 0] = 1.0
+
+    flow_viz = imgviz.flow2rgb(flow_neg)
+
+    assert flow_viz.dtype == np.uint8
+    assert flow_viz.shape == (4, 4, 3)
+    np.testing.assert_array_equal(flow_viz, imgviz.flow2rgb(flow_pos))


### PR DESCRIPTION
A flow vector with a positive u and an IEEE negative-zero v-component makes
`arctan2(-v, -u)` return `+pi`, so the color-wheel index `fk` lands exactly at
`ncols` and `k0`/`k1` ran off the end of the 55-entry colorwheel, raising
`IndexError`. Negative zero arises naturally from sign-flipping zero-valued rows
(e.g. flipping a coordinate axis).

## Summary
- Compute the interpolation weight `f` from the unwrapped `k0`, then wrap
  `k0 == ncols` to the wheel start (the `+pi` endpoint, same as `-pi`) before
  deriving `k1`, mirroring the existing `k1` wrap. The fix is minimal and
  output-preserving: visualization is byte-identical for every non-crashing
  input.
- Regression test: a vector with `-0.0` v visualizes identically to the same
  vector with `+0.0` v.

## Test plan
- [x] `uv run pytest tests/unit/_flow_test.py` (3 passed)
- [x] full suite `uv run pytest -n=auto tests` (183 passed)
- [x] verified outputs byte-identical to pre-fix on random and structured flows
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on changed files
