### PR TITLE
fix: align lb/lb- text to rectangle left edge in text_in_rectangle

### DIFF
--- a/imgviz/draw/_text_in_rectangle.py
+++ b/imgviz/draw/_text_in_rectangle.py
@@ -63,9 +63,9 @@ def text_in_rectangle_aabb(
     elif loc == "rt+":
         yx = (y1 - tsize[0] - 2, x2 - tsize[1] - 2)
     elif loc == "lb":
-        yx = (y2 - tsize[0] - 2, 0)
+        yx = (y2 - tsize[0] - 2, x1)
     elif loc == "lb-":
-        yx = (y2, 0)
+        yx = (y2, x1)
     elif loc == "rb":
         yx = (y2 - tsize[0] - 2, x2 - tsize[1] - 2)
     elif loc == "rb-":

--- a/tests/unit/draw/_text_in_rectangle_test.py
+++ b/tests/unit/draw/_text_in_rectangle_test.py
@@ -1,4 +1,7 @@
+from typing import Literal
+
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -15,3 +18,31 @@ def test_text_in_rectangle() -> None:
     assert res.shape == img.shape
     assert res.dtype == np.uint8
     assert not np.array_equal(res, img)
+
+
+@pytest.mark.parametrize("loc", ["lt", "lt+", "lb", "lb-"])
+def test_text_in_rectangle_aabb_left_aligns_to_x1(
+    loc: Literal["lt", "lt+", "lb", "lb-"],
+) -> None:
+    yx1 = (20, 50)
+    yx2 = (80, 150)
+
+    aabb = imgviz.draw.text_in_rectangle_aabb(
+        yx1=yx1, yx2=yx2, loc=loc, text="Hi", size=10
+    )
+
+    assert aabb.x1 == yx1[1]
+
+
+@pytest.mark.parametrize("loc", ["rt", "rt+", "rb", "rb-"])
+def test_text_in_rectangle_aabb_right_aligns_to_x2(
+    loc: Literal["rt", "rt+", "rb", "rb-"],
+) -> None:
+    yx1 = (20, 50)
+    yx2 = (80, 150)
+
+    aabb = imgviz.draw.text_in_rectangle_aabb(
+        yx1=yx1, yx2=yx2, loc=loc, text="Hi", size=10
+    )
+
+    assert aabb.x2 == yx2[1] - 1  # text right edge sits one pixel inside x2


### PR DESCRIPTION
`text_in_rectangle_aabb` hardcoded the text x-coordinate to `0` for the `lb`
and `lb-` locations instead of using `x1`, the rectangle's left edge. Every
other left-aligned location (`lt`, `lt+`) uses `x1`, so left-bottom text
ignored a non-zero left edge. The default `yx1` of `(0, 0)` masked the bug, and
the only in-repo callers use `lt+`/`lt`, so nothing in `imgviz` regresses; the
fix matters for direct callers of the public `imgviz.draw.text_in_rectangle`.

## Summary
- Use `x1` (not `0`) for the `lb` and `lb-` text x-coordinate, matching the
  symmetric `lt`/`lt+` cases.
- Parametrized tests assert all eight `loc` values align correctly: left
  locations to the rectangle's left edge, right locations to its right edge.

## Test plan
- [x] `uv run pytest tests/unit/draw/_text_in_rectangle_test.py` (9 passed)
- [x] full suite `uv run pytest -n=auto tests` (202 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on changed files
