### PR TITLE
test: cover imgviz.io round-trips and lblsave error paths

### DIFF
--- a/tests/unit/io_test.py
+++ b/tests/unit/io_test.py
@@ -1,9 +1,47 @@
 import pathlib
 
 import numpy as np
+import pytest
 from numpy.typing import NDArray
 
 import imgviz
+
+
+@pytest.mark.parametrize(
+    "shape", [(15, 20, 3), (15, 20, 4), (15, 20)], ids=["rgb", "rgba", "grayscale"]
+)
+def test_imsave_imread_roundtrip(
+    tmp_path: pathlib.Path, shape: tuple[int, ...]
+) -> None:
+    image = np.random.RandomState(0).uniform(0, 255, shape).astype(np.uint8)
+
+    imgviz.io.imsave(tmp_path / "image.png", image)
+    read = imgviz.io.imread(tmp_path / "image.png")
+
+    assert read.dtype == np.uint8
+    np.testing.assert_array_equal(read, image)
+
+
+def test_imsave_creates_parent_dirs(tmp_path: pathlib.Path) -> None:
+    rgb = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    imgviz.io.imsave(tmp_path / "sub" / "deep" / "rgb.png", rgb)
+
+    assert (tmp_path / "sub" / "deep" / "rgb.png").exists()
+
+
+def test_lblsave_rejects_non_png_extension(tmp_path: pathlib.Path) -> None:
+    lbl = np.zeros((4, 4), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match=r"filename must end with '\.png'"):
+        imgviz.io.lblsave(tmp_path / "label.jpg", lbl)
+
+
+def test_lblsave_rejects_non_uint8(tmp_path: pathlib.Path) -> None:
+    lbl = np.zeros((4, 4), dtype=np.int32)
+
+    with pytest.raises(ValueError, match=r"lbl\.dtype must be np\.uint8"):
+        imgviz.io.lblsave(tmp_path / "label.png", lbl)
 
 
 def test_lblsave(tmp_path: pathlib.Path) -> None:
@@ -20,4 +58,4 @@ def test_lblsave(tmp_path: pathlib.Path) -> None:
     imgviz.io.lblsave(png_file, label_cls)
     label_cls_read = imgviz.io.imread(png_file)
 
-    np.testing.assert_allclose(label_cls, label_cls_read)
+    np.testing.assert_array_equal(label_cls, label_cls_read)


### PR DESCRIPTION
`imgviz.io.imsave` had no test coverage, and `lblsave`'s two `ValueError`
guards were untested.

## Summary
- Parametrized `imsave`/`imread` lossless PNG round-trip over rgb, rgba, and
  grayscale (asserts dtype, since `assert_array_equal` does not check it).
- Cover `imsave` creating missing parent directories.
- Cover `lblsave` rejecting a non-`.png` extension and a non-`uint8` dtype.
- Tighten the existing `lblsave` round-trip assertion to `assert_array_equal`
  (the palette PNG round-trip is exact, so the tolerance was needlessly weak).

## Test plan
- [x] `uv run pytest tests/unit/io_test.py` (7 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (253 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
