### PR TITLE
test: cover draw.line validation and ndarray input

### DIFF
--- a/tests/unit/draw/_line_test.py
+++ b/tests/unit/draw/_line_test.py
@@ -1,11 +1,53 @@
 import numpy as np
+import PIL.Image
+import pytest
+from numpy.typing import NDArray
 
 import imgviz
 
 
-def test_line() -> None:
-    img = np.full((100, 100, 3), 255, dtype=np.uint8)
-    res = imgviz.draw.line(img, yx=[(10, 10), (90, 90)], fill=(0, 0, 0))
-    assert res.shape == img.shape
-    assert res.dtype == img.dtype
-    assert not np.array_equal(res, img)
+@pytest.fixture
+def white_image() -> NDArray[np.uint8]:
+    return np.full((100, 100, 3), 255, dtype=np.uint8)
+
+
+def test_line(white_image: NDArray[np.uint8]) -> None:
+    res = imgviz.draw.line(white_image, yx=[(10, 10), (90, 90)], fill=(0, 0, 0))
+    assert res.shape == white_image.shape
+    assert res.dtype == white_image.dtype
+    assert (res[50, 50] == (0, 0, 0)).all()  # line lands on the diagonal
+
+
+def test_line_underscore_mutates_in_place(white_image: NDArray[np.uint8]) -> None:
+    image = PIL.Image.fromarray(white_image)
+
+    imgviz.draw.line_(image, yx=[(10, 10), (90, 90)], fill=(0, 0, 0))
+
+    assert not np.array_equal(np.asarray(image), white_image)
+
+
+def test_line_accepts_ndarray_yx(white_image: NDArray[np.uint8]) -> None:
+    yx = np.array([[10, 10], [90, 90]], dtype=np.float32)
+
+    res = imgviz.draw.line(white_image, yx=yx, fill=(0, 0, 0))
+
+    assert not np.array_equal(res, white_image)
+
+
+def test_line_rejects_non_2d_yx(white_image: NDArray[np.uint8]) -> None:
+    with pytest.raises(ValueError, match="yx must be 2D"):
+        imgviz.draw.line(white_image, yx=[10, 10, 90, 90], fill=(0, 0, 0))
+
+
+def test_line_rejects_wrong_inner_dim(white_image: NDArray[np.uint8]) -> None:
+    with pytest.raises(ValueError, match=r"yx\.shape\[1\] must be 2"):
+        imgviz.draw.line(white_image, yx=[(10, 10, 0), (90, 90, 0)], fill=(0, 0, 0))
+
+
+def test_line_underscore_rejects_numpy_image(white_image: NDArray[np.uint8]) -> None:
+    with pytest.raises(TypeError, match="image must be PIL.Image.Image"):
+        imgviz.draw.line_(
+            white_image,  # type: ignore[arg-type]
+            yx=[(10, 10), (90, 90)],
+            fill=(0, 0, 0),
+        )


### PR DESCRIPTION
`draw.line`/`line_` was the only validating draw primitive without error-path
tests, while `draw.polygon` already had the full set.

## Summary
- Cover `line_`'s three guards: `yx` not 2D, `yx` inner dim != 2 (both
  `ValueError`), and a numpy image passed to `line_` (`TypeError`).
- Cover the `np.ndarray` `yx` input path and `line_` mutating a PIL image in
  place, mirroring the `draw.polygon` tests.
- Tighten the happy-path test to assert the line lands on a specific pixel
  (rather than only that the image changed).

## Test plan
- [x] `uv run pytest tests/unit/draw/_line_test.py` (6 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (252 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
