### PR TITLE
test: cover draw color-ink helpers

### DIFF
--- a/tests/unit/draw/_ink_test.py
+++ b/tests/unit/draw/_ink_test.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from imgviz.draw._ink import Ink
+from imgviz.draw._ink import get_pil_ink
+from imgviz.draw._ink import require_fill_or_outline
+
+
+@pytest.mark.parametrize("ink", [None, 5, (255, 0, 0)], ids=["none", "int", "tuple"])
+def test_get_pil_ink_passes_through_non_ndarray(ink: Ink | None) -> None:
+    assert get_pil_ink(ink) == ink
+
+
+@pytest.mark.parametrize("size", [3, 4], ids=["rgb", "rgba"])
+def test_get_pil_ink_converts_ndarray_to_int_tuple(size: int) -> None:
+    ink = np.arange(1, size + 1, dtype=np.uint8)
+
+    result = get_pil_ink(ink)
+
+    assert isinstance(result, tuple)
+    assert result == tuple(range(1, size + 1))
+    assert all(type(channel) is int for channel in result)  # PIL needs Python ints
+
+
+@pytest.mark.parametrize(
+    "ink",
+    [np.array([[1, 2, 3]], dtype=np.uint8), np.array([1, 2], dtype=np.uint8)],
+    ids=["2d", "wrong-size"],
+)
+def test_get_pil_ink_rejects_invalid_ndarray(ink: NDArray[np.uint8]) -> None:
+    with pytest.raises(ValueError, match="color ndarray must be 1D with size 3 or 4"):
+        get_pil_ink(ink)
+
+
+def test_require_fill_or_outline_rejects_both_none() -> None:
+    with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):
+        require_fill_or_outline(None, None)
+
+
+@pytest.mark.parametrize(
+    ("fill", "outline"),
+    [((255, 0, 0), None), (None, (0, 0, 0)), ((255, 0, 0), (0, 0, 0))],
+    ids=["fill-only", "outline-only", "both"],
+)
+def test_require_fill_or_outline_accepts_when_set(
+    fill: Ink | None, outline: Ink | None
+) -> None:
+    require_fill_or_outline(fill, outline)


### PR DESCRIPTION
`imgviz/draw/_ink.py` was the only source module without a test file, yet
`get_pil_ink` is the color converter every `draw` primitive depends on.

## Summary
- Cover `get_pil_ink`: int and tuple passthrough, `np.ndarray` to
  Python-int-tuple conversion (size 3 and 4), and the `ValueError` for non-1D or
  wrong-size arrays. The conversion to Python ints is asserted explicitly since
  PIL rejects numpy scalars.
- Cover `require_fill_or_outline`: raises when both are `None`, accepts when
  either is set.

## Test plan
- [x] `uv run pytest tests/unit/draw/_ink_test.py` (11 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (258 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the new file
