### PR TITLE
ci: publish to pypi on github release instead of tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 ---
 name: Publish to PyPI
 on:
-  push:
-    tags: [v*]
+  release:
+    types: [published]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -11,6 +11,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Previously any `v*` tag push published to PyPI immediately, decoupled from CI
status, so a bare `git push --tags` was an irreversible release. This gates
publishing behind a published GitHub Release: the Release UI becomes the human
gate, and CI has already run on the target commit on `main`. Also adds
`fetch-depth: 0` so hatch-vcs (`source = "vcs"`) sees full tag history when
resolving the version.

Releasing now becomes `gh release create vX.Y.Z --generate-notes`, which creates
the tag and the Release in one step and fires the publish.

## Test plan
- [x] `publish.yml` validates as YAML
- [x] confirmed hatch-vcs resolves the clean tag version from a checkout at the
      tag (built `imgviz-2.0.1` from a shallow `v2.0.1` checkout)
