### PR TITLE
test: cover blur multi-channel support and validation guards

### DIFF
--- a/tests/unit/_blur_test.py
+++ b/tests/unit/_blur_test.py
@@ -4,7 +4,11 @@ import pytest
 import imgviz
 
 
-@pytest.mark.parametrize("shape", [(40, 50, 3), (40, 50)])
+@pytest.mark.parametrize(
+    "shape",
+    [(40, 50, 3), (40, 50), (40, 50, 4), (40, 50, 5)],
+    ids=["rgb", "gray", "rgba", "five-channel"],
+)
 def test_blur_whole_image(shape: tuple[int, ...]) -> None:
     rng = np.random.default_rng(seed=0)
     img = rng.integers(0, 256, size=shape).astype(np.uint8)
@@ -31,5 +35,19 @@ def test_blur_within_mask() -> None:
 def test_blur_rejects_non_uint8_image() -> None:
     img = np.zeros((40, 50, 3), dtype=np.uint16)
 
-    with pytest.raises(ValueError, match="image.dtype must be uint8"):
+    with pytest.raises(ValueError, match=r"image\.dtype must be uint8"):
+        imgviz.blur(img, sigma=4.0)
+
+
+def test_blur_rejects_negative_sigma() -> None:
+    img = np.zeros((40, 50, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="sigma must be >= 0"):
+        imgviz.blur(img, sigma=-1.0)
+
+
+def test_blur_rejects_invalid_ndim() -> None:
+    img = np.zeros((40, 50, 3, 2), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match=r"image\.ndim must be 2 or 3"):
         imgviz.blur(img, sigma=4.0)


### PR DESCRIPTION
`blur`'s tests covered only rgb and grayscale, leaving two validation guards and
the multi-channel path untested.

## Summary
- Extend the shape parametrize with 4-channel and 5-channel cases, pinning the
  multi-channel support imgviz commits to (ADR 0002). `_gaussian_blur` blurs each
  channel in a loop precisely because PIL cannot construct an arbitrary-channel
  image in one call, so these cases also guard against collapsing that loop.
- Cover the two untested guards: negative `sigma` and `ndim` not in (2, 3).
- Escape the regex dot in the existing dtype-rejection `match` for consistency.

## Test plan
- [x] `uv run pytest tests/unit/_blur_test.py` (8 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (251 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
