### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
       - run: make setup
@@ -26,8 +26,8 @@ jobs:
       matrix:
         python-version: ['3.10']
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
       - run: make setup
@@ -38,16 +38,16 @@ jobs:
       matrix:
         python-version: ['3.10']
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
       - run: make setup
       - run: make test
       - run: |
-          python getting_started.py
+          uv run --extra all python getting_started.py
           for f in examples/*.py; do
-            test -x $f && $f
+            test -x $f && uv run --extra all $f
           done
         env:
           MPLBACKEND: agg

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,19 +7,19 @@ jobs:
   update_readme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.10'
       - run: make setup
       - run: |
-          python getting_started.py
+          uv run --extra all python getting_started.py
           for f in examples/*.py; do
             if [ -x $f ]; then
-              $f --save
+              uv run --extra all $f --save
             fi
           done
-      - run: ./generate_readme.py > README.md
+      - run: uv run --extra all ./generate_readme.py > README.md
       - run: |-
           git config --global user.email "www.kentaro.wada@gmail.com"
           git config --global user.name "Kentaro Wada"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v7
       - run: uv build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
GitHub forces Node-20 actions onto Node 24 starting 2026-06-16, so this bumps every Node-20 action across `ci.yml`, `docs.yml`, and `publish.yml` to its latest Node-24 floating major:

- `actions/checkout@v4` → `@v6` (5 occurrences)
- `astral-sh/setup-uv@v5` / `@v6` → `@v7` (5 occurrences, now uniform)

## Version choices
- Both `checkout@v6` and `setup-uv@v7` declare `using: node24` (verified from their `action.yml`).
- `checkout@v6` is the latest floating major (the issue named `@v5`, but `@v6` is also Node 24 and is the current major; input schema is byte-for-byte identical to v5, so it's a safe drop-in — the `git commit`/`git push` in `docs.yml` and `fetch-depth: 0` in `publish.yml` are unaffected).
- `setup-uv@v7` is the latest **floating** major that runs on Node 24: `astral-sh/setup-uv` publishes no `v8` floating tag (only exact `v8.x` releases), so `@v7` is the right same-major pin matching the repo's `@vN` convention.

## Note on `publish.yml`
`pypa/gh-action-pypi-publish@release/v1` is a **composite** action (not a container, as the issue assumed): it invokes `actions/setup-python@v5.6.0` (Node 20) before running the publish in Docker. So the publish run may still surface a Node-20 annotation from that embedded sub-action. That dependency is SHA-pinned upstream inside pypa's action and tracked by the `@release/v1` floating tag, so it auto-updates when pypa ships a Node-24 `setup-python` — it is out of scope (and not safely overridable) here.

## Test plan
- [x] `checkout@v6` and `setup-uv@v7` `action.yml` confirmed `using: node24`
- [x] no `checkout@v4/v5` or `setup-uv@v5/v6` references remain
- [x] all three workflows parse as valid YAML
- [x] CI run on the PR branch is green and shows no Node-20 deprecation annotation from our direct pins (`pypa/gh-action-pypi-publish`'s embedded `setup-python@v5` runs only on release and is out of scope, per note above)

Closes #183

