### PR TITLE
docs: use modern Actions badge URL pinned to default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <div align="center">
   <a href="https://pypi.python.org/pypi/imgviz"><img src="https://img.shields.io/pypi/v/imgviz.svg"></a>
   <a href="https://pypi.org/project/imgviz"><img src="https://img.shields.io/pypi/pyversions/imgviz.svg"></a>
-  <a href="https://github.com/wkentaro/imgviz/actions"><img src="https://github.com/wkentaro/imgviz/workflows/ci/badge.svg"></a>
+  <a href="https://github.com/wkentaro/imgviz/actions/workflows/ci.yml"><img src="https://github.com/wkentaro/imgviz/actions/workflows/ci.yml/badge.svg"></a>
 </div>
 
 <div align="center">

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -72,7 +72,7 @@ def main() -> None:
 <div align="center">
   <a href="https://pypi.python.org/pypi/imgviz"><img src="https://img.shields.io/pypi/v/imgviz.svg"></a>
   <a href="https://pypi.org/project/imgviz"><img src="https://img.shields.io/pypi/pyversions/imgviz.svg"></a>
-  <a href="https://github.com/wkentaro/imgviz/actions"><img src="https://github.com/wkentaro/imgviz/workflows/ci/badge.svg"></a>
+  <a href="https://github.com/wkentaro/imgviz/actions/workflows/ci.yml"><img src="https://github.com/wkentaro/imgviz/actions/workflows/ci.yml/badge.svg"></a>
 </div>
 
 <div align="center">


### PR DESCRIPTION
The CI badge showed "failing" even though `main` was green. The README used the
legacy `/workflows/ci/badge.svg` URL, which reflects the most recent run across
all branches and events, so a failing PR run flipped the badge. The modern
`/actions/workflows/ci.yml/badge.svg` URL defaults to the default branch.

Adding `?branch=main` to the legacy URL doesn't help (it returns "no status"),
so this switches to the modern endpoint instead.

## Test plan
- [x] `curl .../actions/workflows/ci.yml/badge.svg` returns `ci - passing`
- [x] `uv run python generate_readme.py` regenerates README.md with the new URL
