### PR TITLE
test: cover dtype converter validation guards

### DIFF
--- a/tests/unit/_dtype_test.py
+++ b/tests/unit/_dtype_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -18,3 +19,23 @@ def test_float2ubyte() -> None:
     assert result.dtype == np.uint8
     assert result.shape == img.shape
     np.testing.assert_allclose(result, [[0, 128], [255, 64]])
+
+
+def test_bool2ubyte_rejects_non_bool() -> None:
+    with pytest.raises(ValueError, match="image dtype must be bool"):
+        imgviz.bool2ubyte(np.zeros((2, 2), dtype=np.uint8))
+
+
+def test_float2ubyte_rejects_non_float() -> None:
+    with pytest.raises(ValueError, match="image dtype must be float"):
+        imgviz.float2ubyte(np.zeros((2, 2), dtype=np.uint8))
+
+
+def test_float2ubyte_rejects_below_zero() -> None:
+    with pytest.raises(ValueError, match=r"image\.min\(\) must be >= 0"):
+        imgviz.float2ubyte(np.array([-0.1, 0.5], dtype=np.float32))
+
+
+def test_float2ubyte_rejects_above_one() -> None:
+    with pytest.raises(ValueError, match=r"image\.max\(\) must be <= 1"):
+        imgviz.float2ubyte(np.array([0.5, 1.1], dtype=np.float32))


### PR DESCRIPTION
`bool2ubyte` and `float2ubyte` had four input-validation guards but no
error-path tests.

## Summary
- Cover `bool2ubyte` rejecting a non-bool dtype.
- Cover `float2ubyte` rejecting a non-float dtype, values below 0, and values
  above 1.

## Test plan
- [x] `uv run pytest tests/unit/_dtype_test.py` (6 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (251 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
