### PR TITLE
test: cover normalize multichannel, NaN, and validation paths

### DIFF
--- a/tests/unit/_normalize_test.py
+++ b/tests/unit/_normalize_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -30,3 +31,88 @@ def test_normalize_constant_large_float32_is_finite() -> None:
 
     assert result.shape == src.shape
     assert np.isfinite(result).all()
+
+
+def test_normalize_multichannel_maps_each_channel_to_0_1() -> None:
+    src = np.array(
+        [
+            [[0.0, 5.0, -2.0], [10.0, 15.0, 2.0]],
+            [[5.0, 8.0, 0.0], [2.0, 12.0, 1.0]],
+        ],
+        dtype=np.float32,
+    )
+
+    result = imgviz.normalize(src)
+
+    assert result.shape == src.shape
+    np.testing.assert_allclose(result.min(axis=(0, 1)), [0.0, 0.0, 0.0])
+    np.testing.assert_allclose(result.max(axis=(0, 1)), [1.0, 1.0, 1.0])
+
+
+def test_normalize_multichannel_explicit_minmax() -> None:
+    src = np.array(
+        [[[0.0, 5.0, -2.0], [10.0, 15.0, 2.0]]],
+        dtype=np.float32,
+    )
+
+    # Ranges wider than the data so the explicit override changes the output;
+    # auto min/max would instead map the data to [0, 1].
+    result, min_val, max_val = imgviz.normalize(
+        src,
+        min_value=[-10.0, 0.0, -4.0],
+        max_value=[10.0, 20.0, 4.0],
+        return_minmax=True,
+    )
+
+    assert result.shape == src.shape
+    np.testing.assert_allclose(min_val, [-10.0, 0.0, -4.0])
+    np.testing.assert_allclose(max_val, [10.0, 20.0, 4.0])
+    np.testing.assert_allclose(result[0, 0], [0.5, 0.25, 0.25])
+    np.testing.assert_allclose(result[0, 1], [1.0, 0.75, 0.75])
+
+
+def test_normalize_nan_2d_stays_nan() -> None:
+    src = np.array([[0.0, np.nan], [100.0, 50.0]], dtype=np.float32)
+
+    result = imgviz.normalize(src)
+
+    assert np.isnan(result[0, 1])
+    assert result[0, 0] == 0.0
+    assert result[1, 0] == 1.0
+
+
+def test_normalize_nan_multichannel_marks_whole_pixel() -> None:
+    src = np.tile(np.array([1.0, 2.0, 3.0], dtype=np.float32), (2, 2, 1))
+    src[1, 1, 0] = np.nan
+
+    result = imgviz.normalize(src)
+
+    assert np.isnan(result[1, 1]).all()
+    assert np.isfinite(result[0, 0]).all()
+
+
+def test_normalize_rejects_bad_ndim() -> None:
+    src = np.zeros((2, 2, 2, 2), dtype=np.float32)
+    with pytest.raises(ValueError, match="image ndim must be 2 or 3"):
+        imgviz.normalize(src)
+
+
+@pytest.mark.parametrize(
+    ("min_value", "max_value", "match"),
+    [
+        ([0.0, 0.0], None, r"min_value\.shape must be"),
+        (None, [1.0, 1.0], r"max_value\.shape must be"),
+    ],
+)
+def test_normalize_rejects_wrong_value_shape(
+    min_value: list[float] | None, max_value: list[float] | None, match: str
+) -> None:
+    src = np.zeros((2, 2, 3), dtype=np.float32)
+    with pytest.raises(ValueError, match=match):
+        imgviz.normalize(src, min_value=min_value, max_value=max_value)
+
+
+def test_normalize_warns_on_inf() -> None:
+    src = np.array([[0.0, 50.0], [100.0, 25.0]], dtype=np.float32)
+    with pytest.warns(UserWarning, match=r"some of min or max values are inf\."):
+        imgviz.normalize(src, min_value=0.0, max_value=np.inf)


### PR DESCRIPTION
`normalize` only had happy-path coverage; its multichannel branch, NaN handling,
and four validation/warning guards were untested.

## Summary
- Cover per-channel normalization for a 3-D image (auto and explicit min/max).
- Cover NaN propagation: a NaN stays NaN in 2-D, and a NaN in any channel
  poisons the whole pixel in a multichannel image.
- Cover the `ndim`, `min_value.shape`, and `max_value.shape` `ValueError` guards.
- Cover the `inf` `UserWarning` emitted when a min or max value is infinite.

## Test plan
- [x] `uv run pytest tests/unit/_normalize_test.py` (11 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (255 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
