### PR TITLE
test: cover label2rgb branches and label_colormap immutability

### DIFF
--- a/tests/unit/_label_test.py
+++ b/tests/unit/_label_test.py
@@ -2,8 +2,17 @@ from typing import Literal
 from typing import TypeAlias
 
 import numpy as np
+import pytest
+from numpy.typing import NDArray
 
 import imgviz
+
+
+@pytest.fixture
+def labeled_square() -> NDArray[np.int32]:
+    label = np.zeros((20, 20), dtype=np.int32)
+    label[5:15, 5:15] = 1
+    return label
 
 
 def test_label2rgb() -> None:
@@ -67,3 +76,70 @@ def test_label2rgb_all_unlabeled() -> None:
     labelviz = imgviz.label2rgb(label=label, image=image)
     assert labelviz.dtype == np.uint8
     assert labelviz.shape == (8, 8, 3)
+
+
+def test_label_colormap_is_cached_and_readonly() -> None:
+    cmap = imgviz.label_colormap()
+    assert cmap.shape == (256, 3)
+    assert cmap.dtype == np.uint8
+    assert imgviz.label_colormap() is cmap
+    with pytest.raises(ValueError, match="read-only"):
+        cmap[0] = (1, 2, 3)
+
+
+def test_label2rgb_casts_bool_label() -> None:
+    label = np.array([[True, False], [False, True]], dtype=bool)
+
+    labelviz = imgviz.label2rgb(label=label)
+
+    cmap = imgviz.label_colormap()
+    np.testing.assert_array_equal(labelviz[0, 0], cmap[1])
+    np.testing.assert_array_equal(labelviz[0, 1], cmap[0])
+
+
+def test_label2rgb_accepts_gray_image() -> None:
+    label = np.array([[0, 1], [1, 0]], dtype=np.int32)
+    gray = np.full((2, 2), 100, dtype=np.uint8)
+
+    labelviz = imgviz.label2rgb(label=label, image=gray)
+
+    assert labelviz.dtype == np.uint8
+    assert labelviz.shape == (2, 2, 3)
+    cmap = imgviz.label_colormap()
+    expected_bg = (0.5 * gray[0, 0] + 0.5 * cmap[0]).round().astype(np.uint8)
+    expected_obj = (0.5 * gray[0, 1] + 0.5 * cmap[1]).round().astype(np.uint8)
+    np.testing.assert_array_equal(labelviz[0, 0], expected_bg)
+    np.testing.assert_array_equal(labelviz[0, 1], expected_obj)
+
+
+def test_label2rgb_rejects_out_of_range_alpha() -> None:
+    label = np.array([[0, 1]], dtype=np.int32)
+    with pytest.raises(ValueError, match=r"alpha values must be in \[0, 1\]"):
+        imgviz.label2rgb(label=label, alpha=[0.5, 1.5])
+
+
+def test_label2rgb_dict_label_names_centroid(labeled_square: NDArray[np.int32]) -> None:
+    plain = imgviz.label2rgb(label=labeled_square)
+    labelviz = imgviz.label2rgb(
+        label=labeled_square,
+        label_names={0: "bg", 1: "obj"},
+        loc="centroid",
+    )
+
+    assert labelviz.dtype == np.uint8
+    assert labelviz.shape == (20, 20, 3)
+    assert not np.array_equal(labelviz, plain)  # the dict names were drawn as text
+
+
+def test_label2rgb_thresh_suppress_draws_no_text(
+    labeled_square: NDArray[np.int32],
+) -> None:
+    plain = imgviz.label2rgb(label=labeled_square)
+    suppressed = imgviz.label2rgb(
+        label=labeled_square,
+        label_names={0: "bg", 1: "obj"},
+        loc="centroid",
+        thresh_suppress=1.0,
+    )
+
+    np.testing.assert_array_equal(suppressed, plain)


### PR DESCRIPTION
`label2rgb` had happy-path coverage but several branches were untested, and
`label_colormap`'s caching/immutability had none.

## Summary
- Cover `label_colormap` returning a cached, read-only `(256, 3)` array.
- Cover `label2rgb` casting a bool label (`True`->1, `False`->0 via the colormap).
- Cover gray `(H, W)` image input being promoted to RGB and blended (exact pixel check).
- Cover the out-of-range `alpha` `ValueError` guard.
- Cover dict `label_names` at `loc="centroid"` actually drawing text, and
  `thresh_suppress=1.0` suppressing all centroid text (result equals the plain render).

## Test plan
- [x] `uv run pytest tests/unit/_label_test.py` (8 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (257 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
