### PR TITLE
test: cover text_in_rectangle canvas growth, keep_size, auto color, in-place

### DIFF
--- a/tests/unit/draw/_text_in_rectangle_test.py
+++ b/tests/unit/draw/_text_in_rectangle_test.py
@@ -1,9 +1,16 @@
 from typing import Literal
 
 import numpy as np
+import PIL.Image
 import pytest
+from numpy.typing import NDArray
 
 import imgviz
+
+
+@pytest.fixture
+def small_image() -> NDArray[np.uint8]:
+    return np.full((20, 100, 3), 255, dtype=np.uint8)
 
 
 def test_text_in_rectangle() -> None:
@@ -46,3 +53,57 @@ def test_text_in_rectangle_aabb_right_aligns_to_x2(
     )
 
     assert aabb.x2 == yx2[1] - 1  # text right edge sits one pixel inside x2
+
+
+@pytest.mark.parametrize("loc", ["lt+", "lb-"])
+def test_text_in_rectangle_grows_canvas_for_overflowing_loc(
+    small_image: NDArray[np.uint8], loc: Literal["lt+", "lb-"]
+) -> None:
+    res = imgviz.draw.text_in_rectangle(
+        small_image, loc=loc, text="Hi", size=10, background=(255, 0, 0)
+    )
+
+    assert res.shape[0] > small_image.shape[0]
+    assert res.shape[1] == small_image.shape[1]
+    assert res.dtype == np.uint8
+    # the grown canvas is filled with the background color, not garbage/zeros
+    assert (res == [255, 0, 0]).all(axis=-1).any()
+
+
+def test_text_in_rectangle_keep_size_preserves_shape(
+    small_image: NDArray[np.uint8],
+) -> None:
+    kept = imgviz.draw.text_in_rectangle(
+        small_image, loc="lt+", text="Hi", size=10, background=(0, 0, 0), keep_size=True
+    )
+    grown = imgviz.draw.text_in_rectangle(
+        small_image, loc="lt+", text="Hi", size=10, background=(0, 0, 0)
+    )
+
+    assert kept.shape == small_image.shape
+    assert grown.shape[0] > small_image.shape[0]
+
+
+def test_text_in_rectangle_auto_color_is_white_on_black_background() -> None:
+    img = np.full((40, 100, 3), 255, dtype=np.uint8)
+
+    # with no explicit color, a black background auto-selects white text
+    auto = imgviz.draw.text_in_rectangle(
+        img, loc="lt", text="Hi", size=10, background=(0, 0, 0)
+    )
+    explicit_white = imgviz.draw.text_in_rectangle(
+        img, loc="lt", text="Hi", size=10, background=(0, 0, 0), color=(255, 255, 255)
+    )
+
+    np.testing.assert_array_equal(auto, explicit_white)
+
+
+def test_text_in_rectangle_draws_in_place() -> None:
+    image = PIL.Image.fromarray(np.full((40, 100, 3), 255, dtype=np.uint8))
+    before = np.array(image)
+
+    imgviz.draw.text_in_rectangle_(
+        image, loc="lt", text="Hi", size=10, background=(0, 0, 0)
+    )
+
+    assert not np.array_equal(np.array(image), before)


### PR DESCRIPTION
`text_in_rectangle` had one happy-path test; its canvas-growth, `keep_size`, and
auto-color branches and the in-place `text_in_rectangle_` variant were untested.

## Summary
- Cover canvas growth for overflowing locations (`lt+` pads the top, `lb-` pads
  the bottom), parametrized over `loc`.
- Cover `keep_size=True` preserving the original shape while the default grows it.
- Cover `color=None` auto-detecting a foreground color (white on a black
  background) that differs from forcing black text.
- Cover the in-place `text_in_rectangle_` PIL variant mutating its image.

## Test plan
- [x] `uv run pytest tests/unit/draw/_text_in_rectangle_test.py` (14 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (256 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
