### PR TITLE
test: cover pixelate block guard and oversized-block clamping

### DIFF
--- a/tests/unit/_pixelate_test.py
+++ b/tests/unit/_pixelate_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import imgviz
 
@@ -33,3 +34,20 @@ def test_pixelate_block_one_is_noop() -> None:
     dst = imgviz.pixelate(img, block=1)
 
     np.testing.assert_array_equal(dst, img)
+
+
+@pytest.mark.parametrize("block", [0, -1])
+def test_pixelate_rejects_block_below_one(block: int) -> None:
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="block must be >= 1"):
+        imgviz.pixelate(img, block=block)
+
+
+def test_pixelate_block_exceeds_both_dimensions_yields_uniform() -> None:
+    rng = np.random.default_rng(seed=2)
+    img = rng.integers(0, 256, size=(8, 8, 3)).astype(np.uint8)
+
+    dst = imgviz.pixelate(img, block=100)
+
+    assert dst.shape == img.shape
+    np.testing.assert_array_equal(dst, np.full_like(dst, dst[0, 0]))


### PR DESCRIPTION
`pixelate` had no test for its `block` validation guard or its block-clamping
edge case.

## Summary
- Cover the `block < 1` `ValueError` guard (parametrized over `0` and `-1`).
- Cover an oversized block (larger than both image dimensions): the grid clamps
  to a single 1x1 block, so the output is one uniform color.

## Test plan
- [x] `uv run pytest tests/unit/_pixelate_test.py` (6 passed)
- [x] full suite `uv run --extra all pytest -n=auto tests` (254 passed)
- [x] `uv run ruff check`, `ruff format --check`, `ty check` on the changed file
