### PR TITLE
refactor(draw): extract require_pil_image guard into _ink

### DIFF
--- a/imgviz/draw/_ink.py
+++ b/imgviz/draw/_ink.py
@@ -2,6 +2,7 @@ import typing
 from typing import TypeAlias
 
 import numpy as np
+import PIL.Image
 from numpy.typing import NDArray
 
 Ink: TypeAlias = (
@@ -27,3 +28,10 @@ def get_pil_ink(
 def require_fill_or_outline(fill: Ink | None, outline: Ink | None) -> None:
     if fill is None and outline is None:
         raise ValueError("at least one of `fill` or `outline` must be set")
+
+
+def require_pil_image(*, image: PIL.Image.Image) -> None:
+    if not isinstance(image, PIL.Image.Image):
+        raise TypeError(
+            f"image must be PIL.Image.Image, but got {type(image).__name__}"
+        )

--- a/imgviz/draw/_line.py
+++ b/imgviz/draw/_line.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_pil_image
 
 
 def line(
@@ -45,10 +46,7 @@ def line_(
         fill: RGB color to draw the line.
         width: Line width.
     """
-    if not isinstance(image, PIL.Image.Image):
-        raise TypeError(
-            f"image must be PIL.Image.Image, but got {type(image).__name__}"
-        )
+    require_pil_image(image=image)
     yx = np.asarray(yx)
     if yx.ndim != 2:
         raise ValueError(f"yx must be 2D array, but got {yx.ndim}D")

--- a/imgviz/draw/_polygon.py
+++ b/imgviz/draw/_polygon.py
@@ -8,6 +8,7 @@ from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
+from ._ink import require_pil_image
 
 
 def polygon(
@@ -52,10 +53,7 @@ def polygon_(
         outline: RGB color to draw the outline. None for no outline.
         width: Outline width.
     """
-    if not isinstance(image, PIL.Image.Image):
-        raise TypeError(
-            f"image must be PIL.Image.Image, but got {type(image).__name__}"
-        )
+    require_pil_image(image=image)
     require_fill_or_outline(fill, outline)
     yx = np.asarray(yx)
     if yx.ndim != 2:


### PR DESCRIPTION
Closes #192.

The in-place draw primitives `line_` and `polygon_` each repeated the same
three-line PIL image type guard. This extracts it into `require_pil_image` in
`imgviz/draw/_ink.py`, alongside the existing `require_fill_or_outline`, and
replaces both inline copies. Behavior and the `TypeError` message are unchanged.

## Summary
- Add `require_pil_image(image)` to `imgviz/draw/_ink.py`.
- Replace the inline guard in `line_` and `polygon_` with a call to it.

Scope note: only `line_` and `polygon_` carry the inline guard on `main` today
(`arrow_` arrives with #193 and can adopt the helper there). The other in-place
primitives (`circle_`, `ellipse_`, `rectangle_`, etc.) never had a guard;
applying one to them is a behavior change (they would start raising `TypeError`
instead of a Pillow `AttributeError`), so that uniform rollout is tracked
separately rather than folded into this dedupe.

## Test plan
- [x] full suite `uv run --extra all pytest -n=auto tests` (251 passed)
- [x] the existing `polygon_` "rejects non-PIL image" test still passes, exercising the extracted helper
- [x] `uv run ruff check`, `ty check` on the touched files
