### PR TITLE
test: cover instances2rgb grayscale, dimension guard, and empty-instance skips

### DIFF
--- a/tests/unit/_instances_test.py
+++ b/tests/unit/_instances_test.py
@@ -27,6 +27,13 @@ def test_masks_to_bboxes() -> None:
     assert ((0 <= xmax) & (xmax <= width - 1)).all()
 
 
+def test_masks_to_bboxes_leaves_empty_mask_as_zeros() -> None:
+    masks = [np.zeros((10, 10), dtype=bool)]
+    bboxes = masks_to_bboxes(masks)
+
+    np.testing.assert_array_equal(bboxes, np.zeros((1, 4)))
+
+
 @pytest.fixture
 def image() -> NDArray[np.uint8]:
     return np.full((50, 50, 3), 30, dtype=np.uint8)
@@ -132,3 +139,34 @@ def test_instances2rgb_rejects_non_uint8(
 def test_instances2rgb_rejects_non_array(bbox: list[float]) -> None:
     with pytest.raises(TypeError, match="image must be a numpy array"):
         imgviz.instances2rgb(image=[[1]], labels=[1], bboxes=[bbox])  # type: ignore[arg-type]
+
+
+def test_instances2rgb_accepts_grayscale_image(bbox: list[float]) -> None:
+    gray = np.full((50, 50), 30, dtype=np.uint8)
+
+    out = imgviz.instances2rgb(image=gray, labels=[1], bboxes=[bbox])
+
+    assert out.shape == (50, 50, 3)
+    assert out.dtype == np.uint8
+    np.testing.assert_array_equal(out[0, 0], np.full(3, gray[0, 0]))
+
+
+def test_instances2rgb_rejects_4d_image(bbox: list[float]) -> None:
+    image = np.full((50, 50, 3, 1), 30, dtype=np.uint8)
+    with pytest.raises(ValueError, match="image must be 2 or 3 dimensional"):
+        imgviz.instances2rgb(image=image, labels=[1], bboxes=[bbox])
+
+
+def test_instances2rgb_skips_empty_mask(image: NDArray[np.uint8]) -> None:
+    empty_mask = np.zeros((50, 50), dtype=bool)
+
+    out = imgviz.instances2rgb(image=image, labels=[1], masks=[empty_mask])
+
+    np.testing.assert_array_equal(out, image)
+
+
+def test_instances2rgb_skips_zero_area_bbox(image: NDArray[np.uint8]) -> None:
+    zero_area_bbox = [10.0, 10.0, 10.0, 10.0]
+    out = imgviz.instances2rgb(image=image, labels=[1], bboxes=[zero_area_bbox])
+
+    np.testing.assert_array_equal(out, image)


### PR DESCRIPTION
Adds edge-case and guard coverage for `imgviz/_instances.py`, the last
remaining gap in the coverage campaign for the core compositions. Raises the
module from 92% to 98%; the only line left uncovered is the `skimage`
`ImportError` guard for `boundary_width > 0`, which requires the dependency to
be absent and is awkward to exercise.

New tests:
- `masks_to_bboxes` leaves an all-empty mask as a zero bbox row
- `instances2rgb` promotes a 2-D grayscale image to RGB (asserting the pixel value is preserved)
- `instances2rgb` rejects a 4-D image with the dimension guard
- `instances2rgb` skips an empty mask and a zero-area bbox without drawing

## Test plan
- [x] `uv run --extra all pytest tests/unit/_instances_test.py` (16 passed)
- [x] `uv run --extra all pytest tests` (full suite, 339 passed)
- [x] `ruff format --check`, `ruff check`, `ty check`
- [x] coverage of `imgviz/_instances.py`: 92% -> 98%
