### PR TITLE
chore(makefile): pipe git ls-files into xargs for cleaner echoed commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,18 +32,18 @@ setup:  # Setup dev env
 format:  # Format code
 	$(call exec,$(UV_RUN) ruff format)
 	$(call exec,$(UV_RUN) ruff check --fix)
-	$(call exec,$(UV_RUN) taplo fmt $(shell git ls-files "*.toml"))
-	$(call exec,$(UV_RUN) mdformat $(shell git ls-files "*.md"))
-	$(call exec,$(UV_RUN) yamlfix $(shell git ls-files "*.yml" "*.yaml"))
+	$(call exec,git ls-files "*.toml" | xargs $(UV_RUN) taplo fmt)
+	$(call exec,git ls-files "*.md" | xargs $(UV_RUN) mdformat)
+	$(call exec,git ls-files "*.yml" "*.yaml" | xargs $(UV_RUN) yamlfix)
 	$(call exec,$(UV_RUN) typos --write-changes)
 
 lint:  # Check code
 	$(call exec,$(UV_RUN) ruff format --check)
 	$(call exec,$(UV_RUN) ruff check)
 	$(call exec,$(UV_RUN) ty check --no-progress)
-	$(call exec,$(UV_RUN) taplo fmt --check $(shell git ls-files "*.toml"))
-	$(call exec,$(UV_RUN) mdformat --check $(shell git ls-files "*.md"))
-	$(call exec,$(UV_RUN) yamlfix --check $(shell git ls-files "*.yml" "*.yaml"))
+	$(call exec,git ls-files "*.toml" | xargs $(UV_RUN) taplo fmt --check)
+	$(call exec,git ls-files "*.md" | xargs $(UV_RUN) mdformat --check)
+	$(call exec,git ls-files "*.yml" "*.yaml" | xargs $(UV_RUN) yamlfix --check)
 	$(call exec,$(UV_RUN) typos)
 
 test:


### PR DESCRIPTION
The `$(shell git ls-files ...)` form expanded the matched file list inline, so
the `exec` macro echoed a long, file-stuffed command for the `taplo`, `mdformat`,
and `yamlfix` steps. Piping `git ls-files` into `xargs` keeps the echoed command
short and readable while running the same tools over the same files.

## Test plan
- [x] `make lint` passes with the new echoed commands (e.g. `git ls-files "*.toml" | xargs uv run --extra all taplo fmt --check`)
