### PR TITLE
docs(changelog): backfill unreleased feature entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `tint` for a whole-image color wash ([#204](https://github.com/wkentaro/imgviz/pull/204))
+- Added `heatmap` for visualizing a list of points as a heatmap ([#202](https://github.com/wkentaro/imgviz/pull/202))
+- Added `draw.box_corners` primitive for a corner-only bounding-box style ([#197](https://github.com/wkentaro/imgviz/pull/197))
+- Added `draw.arrow` primitive with an arrowhead at the tip ([#193](https://github.com/wkentaro/imgviz/pull/193))
 - Added `draw.rotated_rectangle` primitive ([#184](https://github.com/wkentaro/imgviz/pull/184))
 - Added `draw.rounded_rectangle` primitive ([#176](https://github.com/wkentaro/imgviz/pull/176))
 


### PR DESCRIPTION
Four user-facing feature PRs merged since v2.1.0 were missing from the `Unreleased` section. This backfills them so the next release notes are complete: `tint` (#204), `heatmap` (#202), `draw.box_corners` (#197), and `draw.arrow` (#193).

Found by diffing `git log v2.1.0..HEAD` against the changelog and filtering out test/docs/ci/dependabot PRs.

## Test plan
- [x] Each entry maps to a merged PR with a confirmed public API name (`tint`, `heatmap`, `draw.box_corners`, `draw.arrow`)
