### PR TITLE
test(tile): cover row/col and channel guards and the auto-shape shrink path

### DIFF
--- a/tests/unit/_tile_test.py
+++ b/tests/unit/_tile_test.py
@@ -77,11 +77,27 @@ def test_tile_pads_short_grid() -> None:
     assert (tiled[:, 12:] == 0).all()
 
 
+def test_tile_auto_shape_shrinks_redundant_row() -> None:
+    wide = [np.full((10, 20, 3), i, dtype=np.uint8) for i in range(4)]
+
+    tiled = imgviz.tile(wide)
+
+    assert tiled.shape == (20, 40, 3)  # 2x2, not a wasteful 3x2 (30, 40, 3)
+
+
 @pytest.mark.parametrize(("row", "col"), [(0, None), (None, 0), (-1, None), (None, -1)])
 def test_tile_rejects_non_positive_row_col(
     images: list[NDArray[np.uint8]], row: int | None, col: int | None
 ) -> None:
     with pytest.raises(ValueError, match="must be positive"):
+        imgviz.tile(images, row=row, col=col)
+
+
+@pytest.mark.parametrize(("row", "col"), [(0, 2), (2, 0), (-1, 2), (2, -1)])
+def test_tile_rejects_non_positive_row_and_col(
+    images: list[NDArray[np.uint8]], row: int, col: int
+) -> None:
+    with pytest.raises(ValueError, match="row and col must be positive"):
         imgviz.tile(images, row=row, col=col)
 
 
@@ -91,6 +107,19 @@ def test_tile_rejects_non_int_dimension(
 ) -> None:
     with pytest.raises(TypeError, match="must be int"):
         imgviz.tile(images, **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("kwargs", [{"row": "1", "col": 2}, {"row": 1, "col": "2"}])
+def test_tile_rejects_non_int_row_and_col(
+    images: list[NDArray[np.uint8]], kwargs: dict[str, object]
+) -> None:
+    with pytest.raises(TypeError, match="must be int"):
+        imgviz.tile(images, **kwargs)  # type: ignore[arg-type]
+
+
+def test_tile_rejects_bad_channel_count() -> None:
+    with pytest.raises(ValueError, match="channel must be 3 or 4"):
+        imgviz.tile([np.zeros((4, 4, 2), dtype=np.uint8)], row=1, col=1)
 
 
 def test_tile_rejects_non_uint8() -> None:


### PR DESCRIPTION
## Summary
- Covers the previously-untested validation branches in `imgviz.tile()`: the combined `row`+`col` guards (both provided but non-positive or non-int) and the `channel not in [3, 4]` guard. The existing tests only exercised the single-dimension (`row`-only / `col`-only) paths.
- Covers the `_get_tile_shape` shrink-back loop via `test_tile_auto_shape_shrinks_redundant_row`: four wide (10x20) images auto-tile to a 2x2 grid rather than a wasteful 3x2.
- Takes `imgviz/_tile.py` from 93% to 99% line coverage. The one remaining uncovered line is the internal `_tile` `border_width` guard, which is unreachable via the public API and whose behavior is under discussion in #212, so it is intentionally left alone.

## Test plan
- [x] `uv run pytest -q` — 390 passed
- [x] `uv run ruff check` / `uv run ruff format --check`
- [x] `uv run ty check`
