### PR TITLE
fix(letterbox): return a copy on the no-op fast path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `draw.rotated_rectangle` primitive ([#184](https://github.com/wkentaro/imgviz/pull/184))
 - Added `draw.rounded_rectangle` primitive ([#176](https://github.com/wkentaro/imgviz/pull/176))
 
+### Fixed
+
+- Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
+
 ## [2.1.0] - 2026-06-10
 
 ### Added

--- a/imgviz/_letterbox.py
+++ b/imgviz/_letterbox.py
@@ -56,7 +56,8 @@ def letterbox(
         loc: Where to place the resized image inside the canvas.
 
     Returns:
-        Letterboxed image, or tuple of (image, mask) if return_mask is True.
+        A new letterboxed image (never a view of ``image``), or tuple of
+        (image, mask) if return_mask is True.
     """
     if image.ndim == 3:
         shape: tuple[int, ...] = (height, width, image.shape[2])
@@ -65,9 +66,9 @@ def letterbox(
 
     if image.shape[:2] == shape[:2]:
         if return_mask:
-            return image, np.ones(shape[:2], dtype=bool)
+            return image.copy(), np.ones(shape[:2], dtype=bool)
         else:
-            return image
+            return image.copy()
 
     image_h, image_w = image.shape[:2]
     scale = min(1.0 * height / image_h, 1.0 * width / image_w)

--- a/tests/unit/_letterbox_test.py
+++ b/tests/unit/_letterbox_test.py
@@ -101,6 +101,28 @@ def test_letterbox_identity_when_shape_matches() -> None:
     np.testing.assert_array_equal(dst, img)
 
 
+def test_letterbox_returns_copy_when_shape_matches() -> None:
+    img = np.random.uniform(0, 255, size=(20, 20, 3)).round().astype(np.uint8)
+    original = img.copy()
+
+    dst = imgviz.letterbox(img, height=20, width=20)
+    assert not np.shares_memory(dst, img)
+    dst[...] = 0
+    np.testing.assert_array_equal(img, original)
+
+
+def test_letterbox_returns_copy_when_shape_matches_with_mask() -> None:
+    img = np.random.uniform(0, 255, size=(20, 20, 3)).round().astype(np.uint8)
+    original = img.copy()
+
+    dst, mask = imgviz.letterbox(img, height=20, width=20, return_mask=True)
+    assert not np.shares_memory(dst, img)
+    dst[...] = 0
+    np.testing.assert_array_equal(img, original)
+    assert mask.shape == (20, 20)
+    assert mask.all()
+
+
 _Loc: TypeAlias = Literal["center", "lt", "rt", "lb", "rb"]
 
 


### PR DESCRIPTION
`letterbox()` allocates a fresh array in every branch except the
shape-already-matches fast path, which returned the caller's own array
unchanged. Mutating the result then silently corrupted the input whenever the
image already matched the target size, violating the immutability contract the
other branches and ADR 0002 principle 3 ("functional variants return new
arrays") uphold.

The fix returns `image.copy()` on both the plain and `return_mask` branches, so
the output is always independent of the input. The docstring now documents the
copy guarantee (mirroring `pad()`'s wording).

## Test plan
- [x] Added `test_letterbox_returns_copy_when_shape_matches` and
      `..._with_mask`, asserting `not np.shares_memory(dst, img)` plus
      mutate-then-compare
- [x] `uv run --extra all pytest` (384 passed)
- [x] `make lint` (ruff format/check, ty)
