### PR TITLE
test(heatmap): cover boundary window skip and edge clipping

### DIFF
--- a/tests/unit/_heatmap_test.py
+++ b/tests/unit/_heatmap_test.py
@@ -18,6 +18,23 @@ def test_heatmap_empty_is_zero() -> None:
     np.testing.assert_array_equal(res, np.zeros((100, 100)))
 
 
+def test_heatmap_skips_point_whose_window_is_outside_image() -> None:
+    inside = imgviz.heatmap([(50, 50)], shape=(100, 100), sigma=10)
+    with_outside = imgviz.heatmap([(50, 50), (-40, 50)], shape=(100, 100), sigma=10)
+    np.testing.assert_array_equal(with_outside, inside)
+
+
+def test_heatmap_all_points_outside_image_is_zero() -> None:
+    res = imgviz.heatmap([(-40, 50), (50, -40)], shape=(100, 100), sigma=10)
+    np.testing.assert_array_equal(res, np.zeros((100, 100)))
+
+
+def test_heatmap_clips_window_at_image_edge() -> None:
+    res = imgviz.heatmap([(5, 50)], shape=(100, 100), sigma=10)
+    assert res[5, 50] == pytest.approx(1.0)  # peak survives the top clip
+    assert res[0, 50] == pytest.approx(np.exp(-(5**2) / (2 * 10**2)))
+
+
 def test_heatmap_peak_equals_weight_and_falls_off() -> None:
     res = imgviz.heatmap([(50, 50)], shape=(100, 100), sigma=10)
     assert res[50, 50] == pytest.approx(1.0)


### PR DESCRIPTION
`heatmap()` clips each point's ±3σ window to the image, and skips a point whose
window falls entirely outside via `if y0 >= y1 or x0 >= x1: continue`. That skip
branch and the values produced by a partially-clipped window were previously
unexercised (`imgviz/_heatmap.py` line 67), so this adds three regression tests
covering boundary window handling and brings the module to full line coverage.

The out-of-frame points use moderate offsets (e.g. `(-40, 50)`) rather than
extreme ones (`(-500, -500)`): with an extreme point, numpy's slice
normalization makes the loop a silent no-op even if the guard were removed, so
the test would pass regardless. A moderate negative point makes the guard
load-bearing — without it the code raises a broadcast-shape `ValueError` —
verified by removing the guard and watching both tests fail.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_heatmap_test.py` (20 passed)
- [x] `imgviz/_heatmap.py` coverage 97% -> 100% (full suite: 385 passed)
- [x] `make lint` (ruff format/check, ty) clean
- [x] mutation check: deleting the skip guard makes both out-of-frame tests fail
