### PR TITLE
fix(color): validate input in rgb2hsv and hsv2rgb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `draw.rotated_rectangle` primitive ([#184](https://github.com/wkentaro/imgviz/pull/184))
 - Added `draw.rounded_rectangle` primitive ([#176](https://github.com/wkentaro/imgviz/pull/176))
 
+### Changed
+
+- Changed `rgb2hsv` and `hsv2rgb` to validate input shape and dtype and raise a clear `ValueError`, matching the other color converters, instead of surfacing a confusing error from Pillow ([#222](https://github.com/wkentaro/imgviz/pull/222))
+
 ### Fixed
 
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))

--- a/imgviz/_color.py
+++ b/imgviz/_color.py
@@ -77,6 +77,13 @@ def rgb2hsv(rgb: NDArray[np.uint8]) -> NDArray[np.uint8]:
     Returns:
         HSV image with shape (H, W, 3).
     """
+    if rgb.ndim != 3:
+        raise ValueError(f"rgb must be 3 dimensional, but got {rgb.ndim}")
+    if rgb.shape[2] != 3:
+        raise ValueError(f"rgb shape must be (H, W, 3), but got {rgb.shape}")
+    if rgb.dtype != np.uint8:
+        raise ValueError(f"rgb dtype must be np.uint8, but got {rgb.dtype}")
+
     hsv = _utils.numpy_to_pillow(rgb, mode="RGB")
     hsv = hsv.convert("HSV")
     hsv = _utils.pillow_to_numpy(hsv)
@@ -92,6 +99,13 @@ def hsv2rgb(hsv: NDArray[np.uint8]) -> NDArray[np.uint8]:
     Returns:
         RGB image with shape (H, W, 3).
     """
+    if hsv.ndim != 3:
+        raise ValueError(f"hsv must be 3 dimensional, but got {hsv.ndim}")
+    if hsv.shape[2] != 3:
+        raise ValueError(f"hsv shape must be (H, W, 3), but got {hsv.shape}")
+    if hsv.dtype != np.uint8:
+        raise ValueError(f"hsv dtype must be np.uint8, but got {hsv.dtype}")
+
     rgb = _utils.numpy_to_pillow(hsv, mode="HSV")
     rgb = rgb.convert("RGB")
     rgb = _utils.pillow_to_numpy(rgb)

--- a/tests/unit/_color_test.py
+++ b/tests/unit/_color_test.py
@@ -89,7 +89,7 @@ def test_get_fg_color() -> None:
     assert get_fg_color((255, 255, 255)) == (0, 0, 0)
 
 
-@pytest.mark.parametrize("convert", [imgviz.rgb2gray, imgviz.rgb2rgba])
+@pytest.mark.parametrize("convert", [imgviz.rgb2gray, imgviz.rgb2rgba, imgviz.rgb2hsv])
 @pytest.mark.parametrize(
     ("image", "match"),
     [
@@ -117,6 +117,20 @@ def test_rgb_converter_rejects_invalid(
 def test_gray2rgb_rejects_invalid(image: NDArray, match: str) -> None:
     with pytest.raises(ValueError, match=match):
         imgviz.gray2rgb(image)
+
+
+@pytest.mark.parametrize(
+    ("image", "match"),
+    [
+        (np.zeros((4, 4), dtype=np.uint8), "hsv must be 3 dimensional"),
+        (np.zeros((4, 4, 4), dtype=np.uint8), r"hsv shape must be \(H, W, 3\)"),
+        (np.zeros((4, 4, 3), dtype=np.float32), r"hsv dtype must be np\.uint8"),
+    ],
+    ids=["non-3d", "wrong-channels", "non-uint8"],
+)
+def test_hsv2rgb_rejects_invalid(image: NDArray, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        imgviz.hsv2rgb(image)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`rgb2hsv` and `hsv2rgb` handed their input straight to Pillow, so an array with
the wrong ndim, channel count, or dtype surfaced a confusing `PIL`/`TypeError`
from deep inside Pillow instead of the clear `ValueError` the sibling converters
(`rgb2gray`, `gray2rgb`, `rgb2rgba`) already raise. This adds the same shape and
dtype guards so all the color converters enforce their documented `(H, W, 3)`
uint8 contract consistently. Valid inputs are unaffected.

## Test plan
- [x] Added guard cases to `tests/unit/_color_test.py` (`rgb2hsv` folded into the
      existing `test_rgb_converter_rejects_invalid`; new `test_hsv2rgb_rejects_invalid`)
- [x] `uv run --extra all pytest -n=auto tests` (401 passed)
- [x] `uv run ruff check` / `uv run ty check` clean
