### PR TITLE
fix(legend): round the translucent background wash instead of truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
+- Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))
 
 ## [2.1.0] - 2026-06-10
 

--- a/imgviz/components/_legend.py
+++ b/imgviz/components/_legend.py
@@ -97,7 +97,7 @@ def legend_(
     y1, x1 = yx1.round().astype(int)
     y2, x2 = yx2.round().astype(int)
     region = np.asarray(image)[y1:y2, x1:x2]
-    washed = (alpha * region + alpha * 255).astype(np.uint8)
+    washed = (alpha * region + alpha * 255).round().astype(np.uint8)
     image.paste(_utils.numpy_to_pillow(washed), (int(x1), int(y1)))
 
     box_size = text_height - 2 * pad

--- a/tests/unit/components/_legend_test.py
+++ b/tests/unit/components/_legend_test.py
@@ -22,6 +22,19 @@ def test_legend_preserves_shape_and_dtype(white_image: NDArray[np.uint8]) -> Non
     assert not np.array_equal(res, white_image)
 
 
+def test_legend_wash_rounds_to_nearest() -> None:
+    image = np.full((80, 120, 3), 200, dtype=np.uint8)
+    res = imgviz.components.legend(
+        image,
+        items=[("a", (255, 0, 0)), ("bb", (0, 255, 0))],
+        loc="lt",
+    )
+    # wash blends the region toward white at alpha=0.5:
+    # 0.5 * 200 + 0.5 * 255 = 227.5, which must round to the nearest integer
+    # (228), not truncate down to 227.
+    assert res[5, 5].tolist() == [228, 228, 228]
+
+
 def test_legend_empty_items_is_noop(white_image: NDArray[np.uint8]) -> None:
     res = imgviz.components.legend(white_image, items=[])
     assert np.array_equal(res, white_image)


### PR DESCRIPTION
The corner legend blends its background region toward white at `alpha=0.5` via
`(alpha * region + alpha * 255).astype(np.uint8)`, which truncates the float
result. For any region value landing on a `.5` boundary (about half of all
values) this biased the blended pixel down by one, e.g. a region value of 200
washed to 227 instead of 228.

Round before casting, matching the round-before-uint8 convention already used
in `fill._blend` and `_colorize` (and every other blend site in the codebase).

## Test plan
- [x] added `test_legend_wash_rounds_to_nearest` pinning the washed pixel value (region 200 -> 228)
- [x] `uv run --all-extras pytest -q` (396 passed)
- [x] `uv run ruff check` / `uv run ty check` clean
