### PR TITLE
fix(draw): fill text_in_rectangle grown canvas with full background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
+- Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 
 ## [2.1.0] - 2026-06-10
 

--- a/imgviz/draw/_text_in_rectangle.py
+++ b/imgviz/draw/_text_in_rectangle.py
@@ -8,6 +8,7 @@ import PIL.Image
 from numpy.typing import NDArray
 
 from .. import _color
+from .. import _pad
 from .. import _utils
 from ._rectangle import rectangle_
 from ._text import text_
@@ -128,29 +129,14 @@ def text_in_rectangle(
     dst = image
 
     if not keep_size:
-        constant_values = (
-            (background[0],),
-            (background[1],),
-            (background[2],),
-        )
         if y1 < 0:
             pad = -y1
-            dst = np.pad(
-                dst,
-                ((pad, 0), (0, 0), (0, 0)),
-                mode="constant",
-                constant_values=constant_values,
-            )
+            dst = _pad.pad(image=dst, top=pad, color=background)
             y1 += pad
             y2 += pad
         if y2 > height:
             pad = y2 - height
-            dst = np.pad(
-                dst,
-                ((0, pad), (0, 0), (0, 0)),
-                mode="constant",
-                constant_values=constant_values,
-            )
+            dst = _pad.pad(image=dst, bottom=pad, color=background)
 
     dst = _utils.numpy_to_pillow(dst)
     rectangle_(

--- a/tests/unit/draw/_text_in_rectangle_test.py
+++ b/tests/unit/draw/_text_in_rectangle_test.py
@@ -70,6 +70,22 @@ def test_text_in_rectangle_grows_canvas_for_overflowing_loc(
     assert (res == [255, 0, 0]).all(axis=-1).any()
 
 
+@pytest.mark.parametrize(("loc", "corner"), [("lt+", 0), ("lb-", -1)])
+def test_text_in_rectangle_pads_with_full_background_color(
+    small_image: NDArray[np.uint8], loc: Literal["lt+", "lb-"], corner: int
+) -> None:
+    background = (200, 50, 10)
+
+    res = imgviz.draw.text_in_rectangle(
+        small_image, loc=loc, text="Hi", size=10, background=background
+    )
+
+    # the grown row lies outside the narrow left-aligned rectangle at its right
+    # edge, so it must carry the full background triplet, not background[0]
+    # replicated across every channel.
+    np.testing.assert_array_equal(res[corner, -1], background)
+
+
 def test_text_in_rectangle_keep_size_preserves_shape(
     small_image: NDArray[np.uint8],
 ) -> None:


### PR DESCRIPTION
`text_in_rectangle` grows the canvas to fit text placed with an overflowing
`loc` (`lt+`, `rt+`, `lb-`, `rb-`). The grown rows were filled via a hand-rolled
`np.pad(..., constant_values=((r,), (g,), (b,)))`, but `np.pad` indexes
`constant_values` per padded axis, not per channel. Only axis 0 was padded, so
every grown pixel got `background[0]` (the red channel) replicated across all
three channels instead of the intended RGB triplet, e.g. a `(200, 50, 10)`
background produced `(200, 200, 200)` in the padded border.

The fix delegates to the existing `_pad.pad` helper (already used by
`letterbox`), which fills per channel correctly, and deletes the broken inline
reimplementation.

## Test plan
- [x] New regression test `test_text_in_rectangle_pads_with_full_background_color`, parametrized over the top-pad (`lt+`) and bottom-pad (`lb-`) branches, asserts a padded corner carries the full background triplet. Verified it fails on `main` (`[200, 200, 200]`) and passes here.
- [x] `uv run --extra all pytest` — 396 passed
- [x] `uv run ruff check` / `ruff format --check` / `uv run ty check` on the changed files
