### PR TITLE
refactor(fill): drop redundant mask AND in Stripe blend

### DIFF
--- a/imgviz/fill.py
+++ b/imgviz/fill.py
@@ -112,7 +112,7 @@ class Stripe(Fill):
         stripe_mask[ys[stripe_on], xs[stripe_on]] = True
         return _blend(
             image=image,
-            mask=mask & stripe_mask,
+            mask=stripe_mask,
             color=self.color,
             alpha=alpha,
             copy=copy,


### PR DESCRIPTION
`Stripe.__call__` built `stripe_mask` by scattering `True` only at coordinates from `np.nonzero(mask)`, so it is a subset of `mask` by construction and `mask & stripe_mask` always equals `stripe_mask`. Pass `stripe_mask` directly, dropping a wasted `(H, W)` bool allocation and elementwise AND per fill. Output is byte-identical.

## Test plan
- [x] `uv run --extra all pytest -n=auto tests` (403 passed), incl. `test_mask2rgb_stripe` which asserts stripe density and background
- [x] `ruff check` / `ruff format --check` / `ty check` on `imgviz/fill.py`
- [x] Smoke: `mask2rgb` with `Stripe` renders ~50% stripe duty cycle, no leak outside mask, empty-mask edge case clean