### PR TITLE
test: cover flags2rgb ndim guard for non-2D/3D images

### DIFF
--- a/tests/unit/_flags_test.py
+++ b/tests/unit/_flags_test.py
@@ -146,6 +146,13 @@ def test_flags2rgb_validates_inputs(black_image: NDArray[np.uint8]) -> None:
             centers=centers,
             flag_names=flag_names,
         )
+    with pytest.raises(ValueError, match="image must be 2 or 3 dimensional"):
+        imgviz.flags2rgb(
+            np.zeros((10,), dtype=np.uint8),
+            flags=flags,
+            centers=centers,
+            flag_names=flag_names,
+        )
     with pytest.raises(TypeError, match="flags must be a numpy array"):
         imgviz.flags2rgb(
             black_image,


### PR DESCRIPTION
Completes guard-test coverage for `flags2rgb`. Every other validation guard in
`imgviz/_flags.py` is already exercised by `test_flags2rgb_validates_inputs`, but
the `image must be 2 or 3 dimensional` guard had no test; this adds the missing
case (a 1-D `uint8` array), bringing the module's guard tests to 1:1 with its
`raise` sites (line coverage 98% -> 100%). Source is untouched.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_flags_test.py -q` (10 passed)
