### PR TITLE
feat(flags2rgb): expose pie outline color and width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `outline` and `outline_width` parameters to `flags2rgb` to override the pie glyph outline color and width ([#229](https://github.com/wkentaro/imgviz/pull/229))
 - Added `tint` for a whole-image color wash ([#204](https://github.com/wkentaro/imgviz/pull/204))
 - Added `heatmap` for visualizing a list of points as a heatmap ([#202](https://github.com/wkentaro/imgviz/pull/202))
 - Added `colorblind` for simulating color-vision deficiency ([#199](https://github.com/wkentaro/imgviz/pull/199))

--- a/imgviz/_flags.py
+++ b/imgviz/_flags.py
@@ -25,6 +25,8 @@ def flags2rgb(
     font_size: int = 25,
     font_path: str | None = None,
     loc: Literal["lt", "rt", "lb", "rb"] = "rb",
+    outline: draw_module.Ink | None = (255, 255, 255),
+    outline_width: int = 1,
 ) -> NDArray[np.uint8]:
     """Visualize per-instance boolean flags as pie glyphs with a legend.
 
@@ -48,6 +50,8 @@ def flags2rgb(
         font_size: Font size of the legend.
         font_path: Font path.
         loc: Location of legend ('lt', 'rt', 'lb', 'rb').
+        outline: Color for the pie and wedge edges. None for no outline.
+        outline_width: Width of the pie outline in pixels.
 
     Returns:
         Visualized image with shape (H, W, 3).
@@ -111,8 +115,8 @@ def flags2rgb(
             center=(cy, cx),
             diameter=diameter,
             fills=fills,
-            outline=(255, 255, 255),
-            width=1,
+            outline=outline,
+            width=outline_width,
         )
 
     items: list[components.LegendItem] = list(zip(flag_names, flag_colors))

--- a/tests/unit/_flags_test.py
+++ b/tests/unit/_flags_test.py
@@ -127,6 +127,44 @@ def test_flags2rgb_custom_flag_colors(black_image: NDArray[np.uint8]) -> None:
     assert np.array_equal(res[100, 100], (255, 255, 0))
 
 
+def test_flags2rgb_outline_defaults_to_white(black_image: NDArray[np.uint8]) -> None:
+    res = imgviz.flags2rgb(
+        black_image,
+        flags=np.array([[True]]),
+        centers=np.array([[100.0, 100.0]]),
+        flag_names=["broken"],
+    )
+    disc = res[85:115, 85:115]
+    assert (disc == (255, 255, 255)).all(axis=2).any()
+
+
+def test_flags2rgb_custom_outline_color(black_image: NDArray[np.uint8]) -> None:
+    flags = np.array([[True]])
+    centers = np.array([[100.0, 100.0]])
+    flag_names = ["broken"]
+    white = imgviz.flags2rgb(
+        black_image,
+        flags=flags,
+        centers=centers,
+        flag_names=flag_names,
+        outline=(255, 255, 255),
+        outline_width=3,
+    )
+    black = imgviz.flags2rgb(
+        black_image,
+        flags=flags,
+        centers=centers,
+        flag_names=flag_names,
+        outline=(0, 0, 0),
+        outline_width=3,
+    )
+
+    assert not np.array_equal(white, black)
+    disc = slice(85, 115)
+    assert (white[disc, disc] == (255, 255, 255)).all(axis=2).any()
+    assert not (black[disc, disc] == (255, 255, 255)).all(axis=2).any()
+
+
 def test_flags2rgb_validates_inputs(black_image: NDArray[np.uint8]) -> None:
     flags = np.array([[True]])
     centers = np.array([[100.0, 100.0]])


### PR DESCRIPTION
## Summary

- Add `outline` and `outline_width` parameters to `flags2rgb`, forwarded straight to the underlying `pie_` call.
- Defaults stay `(255, 255, 255)` / `1`, so existing callers get byte-identical output.
- Lets callers pick a readable outline (e.g. black `(0, 0, 0)`) when the white one washes out on bright backgrounds or between similar wedge colors, replacing the previous `imgviz.draw.pie_` monkey-patch workaround.

## Test plan

- [x] added `test_flags2rgb_outline_defaults_to_white` and `test_flags2rgb_custom_outline_color` in `tests/unit/_flags_test.py`
- [x] `uv run pytest tests/unit/_flags_test.py` (12 passed)
- [x] `uv run ruff check` / `ruff format --check` / `ty check`

Closes #228
