### PR TITLE
test: cover unsupported-loc guards in letterbox, text_in_rectangle, legend

### DIFF
--- a/tests/unit/_letterbox_test.py
+++ b/tests/unit/_letterbox_test.py
@@ -205,3 +205,9 @@ def test_letterbox_loc_landscape(loc: _Loc, show: bool) -> None:
             assert (dst[-size_diff:, :] != 0).all()
         case _:
             raise ValueError(f"unknown loc: {loc}")
+
+
+def test_letterbox_rejects_unsupported_loc() -> None:
+    img = np.zeros((10, 20, 3), dtype=np.uint8)
+    with pytest.raises(ValueError, match="unsupported loc"):
+        imgviz.letterbox(img, height=20, width=20, loc="bogus")  # type: ignore[arg-type]

--- a/tests/unit/components/_legend_test.py
+++ b/tests/unit/components/_legend_test.py
@@ -62,3 +62,12 @@ def test_legend_loc_places_in_corner(
     non_white = ~(res == 255).all(axis=2)
     assert non_white.any()
     assert non_white.sum() == non_white[corner].sum()
+
+
+def test_legend_rejects_unsupported_loc(white_image: NDArray[np.uint8]) -> None:
+    with pytest.raises(ValueError, match="unsupported loc"):
+        imgviz.components.legend(
+            white_image,
+            items=[("cat", (255, 0, 0))],
+            loc="bogus",  # type: ignore[arg-type]
+        )

--- a/tests/unit/draw/_text_in_rectangle_test.py
+++ b/tests/unit/draw/_text_in_rectangle_test.py
@@ -123,3 +123,16 @@ def test_text_in_rectangle_draws_in_place() -> None:
     )
 
     assert not np.array_equal(np.array(image), before)
+
+
+def test_text_in_rectangle_rejects_unsupported_loc(
+    small_image: NDArray[np.uint8],
+) -> None:
+    with pytest.raises(ValueError, match="unsupported loc"):
+        imgviz.draw.text_in_rectangle(
+            small_image,
+            loc="bogus",  # type: ignore[arg-type]
+            text="Hi",
+            size=10,
+            background=(0, 0, 0),
+        )


### PR DESCRIPTION
`letterbox`, `draw.text_in_rectangle`, and `components.legend` each raise
`ValueError("unsupported loc: ...")` on an unrecognized `loc`, but that guard
branch was untested in all three. This adds one invalid-`loc` test per function
(using the established `# type: ignore[arg-type]` idiom, matching the existing
`backend="bogus"` / `mode="bogus"` guard tests), bringing all three modules to
full line coverage.

## Test plan
- [x] `uv run --extra all pytest tests` (425 passed)
- [x] `make lint` (ruff format, ruff check, ty all clean)
- [x] Coverage of `_letterbox.py`, `_text_in_rectangle.py`, `_legend.py` now 100%
