### PR TITLE
docs: document grayscale input in label2rgb, instances2rgb, flags2rgb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Documented that `label2rgb`, `instances2rgb`, and `flags2rgb` accept a grayscale `(H, W)` image in addition to `(H, W, 3)`, matching the input they already convert internally ([#232](https://github.com/wkentaro/imgviz/pull/232))
 - Changed `rgb2hsv` and `hsv2rgb` to validate input shape and dtype and raise a clear `ValueError`, matching the other color converters, instead of surfacing a confusing error from Pillow ([#222](https://github.com/wkentaro/imgviz/pull/222))
 
 ### Fixed

--- a/imgviz/_flags.py
+++ b/imgviz/_flags.py
@@ -39,7 +39,7 @@ def flags2rgb(
     entry. Around 5 wedges stay legible at the default diameter.
 
     Args:
-        image: RGB image with shape (H, W, 3).
+        image: Image with shape (H, W) or (H, W, 3).
         flags: Boolean flags with shape (N, F).
         centers: Pie centers with shape (N, 2). [(cy, cx), ...]
         flag_names: Flag names with length F.

--- a/imgviz/_instances.py
+++ b/imgviz/_instances.py
@@ -51,7 +51,7 @@ def instances2rgb(
     """Convert instances to rgb.
 
     Args:
-        image: RGB image with shape (H, W, 3).
+        image: Image with shape (H, W) or (H, W, 3).
         labels: Labels with length N.
         bboxes: Bounding boxes with shape (N, 4).
         masks: Masks with shape (N, H, W).

--- a/imgviz/_label.py
+++ b/imgviz/_label.py
@@ -52,7 +52,7 @@ def label2rgb(
 
     Args:
         label: Label image with shape (H, W).
-        image: RGB image with shape (H, W, 3).
+        image: Image with shape (H, W) or (H, W, 3).
         alpha: Alpha of RGB. If given as a list or dict, it is treated as alpha
             for each class according to the index or key.
         label_names: Label id to label name.


### PR DESCRIPTION
`label2rgb`, `instances2rgb`, and `flags2rgb` all promote a grayscale `(H, W)`
image to RGB via `gray2rgb` before blending, but their `image` docstrings claimed
the input must be `(H, W, 3)`. This documents the shapes they actually accept,
matching the `(H, W) or (H, W, C)` wording already used by `blur`, `pad`, `resize`,
`pixelate`, and `io`.

Docs-only; no behavior change.

Out of scope, noted for awareness: `instances2rgb` and `flags2rgb` validate the
image with an `ndim`-only guard, so an `(H, W, 4)` RGBA array is not rejected and
either passes through unconverted or fails later with a raw NumPy broadcast error.
That is a pre-existing validation gap, not addressed here.

## Test plan
- [x] `make lint` and `uv run pytest -n=auto tests` green (475 passed; docstring-only, no behavior touched)
