### PR TITLE
test(draw): cover text_size blank-line height accumulation

### DIFF
--- a/tests/unit/draw/_text_test.py
+++ b/tests/unit/draw/_text_test.py
@@ -17,3 +17,9 @@ def test_text_size() -> None:
     assert isinstance(width, int)
     assert height > 0
     assert width > 0
+
+
+def test_text_size_blank_line_adds_height() -> None:
+    height_without, _ = imgviz.draw.text_size("a\nb", size=20)
+    height_with, _ = imgviz.draw.text_size("a\n\nb", size=20)
+    assert height_with > height_without


### PR DESCRIPTION
`text_size` substitutes a blank line with `"\n"` so it still contributes vertical
height, but the existing `test_text_size` only exercises a single-line string, so
that branch was untested. This adds a multi-line case asserting a blank line
increases the reported height, bringing `imgviz/draw/_text.py` to 100% coverage.

## Test plan
- [x] `uv run --extra all pytest -n=auto tests` (476 passed)
- [x] `imgviz/draw/_text.py` coverage 97% -> 100%
- [x] `make lint` (ruff format, ruff check, ty) clean on the touched file
