### PR TITLE
refactor(data): extract shared class_label and class_names helpers

### DIFF
--- a/imgviz/data/_utils.py
+++ b/imgviz/data/_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+def compose_class_label(
+    shape: tuple[int, int],
+    labels: NDArray[np.int32],
+    masks: NDArray,
+) -> NDArray[np.int32]:
+    """Compose per-instance masks into a class label image."""
+    class_label: NDArray[np.int32] = np.full(shape, 0, dtype=np.int32)
+    for label_id, mask in zip(labels, masks):
+        class_label[mask == 1] = label_id
+    return class_label
+
+
+def read_class_names(path: pathlib.Path) -> list[str]:
+    """Read newline-delimited class names from a text file."""
+    with open(path) as f:
+        return [name.strip() for name in f]

--- a/imgviz/data/arc2017/__init__.py
+++ b/imgviz/data/arc2017/__init__.py
@@ -6,6 +6,8 @@ from typing import TypedDict
 import numpy as np
 from numpy.typing import NDArray
 
+from .. import _utils
+
 _here: pathlib.Path = pathlib.Path(__file__).parent
 
 
@@ -25,14 +27,10 @@ def arc2017() -> _Arc2017Data:
     data_file: pathlib.Path = _here / "data.npz"
     data: dict = dict(np.load(data_file))
 
-    # compose masks to class label image
-    class_label: NDArray[np.int32] = np.full(data["rgb"].shape[:2], 0, dtype=np.int32)
-    for label_id, mask in zip(data["labels"], data["masks"]):
-        class_label[mask == 1] = label_id
-
-    names_file: pathlib.Path = _here / "class_names.txt"
-    with open(names_file) as f:
-        class_names = [name.strip() for name in f]
+    class_label = _utils.compose_class_label(
+        shape=data["rgb"].shape[:2], labels=data["labels"], masks=data["masks"]
+    )
+    class_names = _utils.read_class_names(_here / "class_names.txt")
 
     res4: NDArray[np.float32] = np.load(_here / "res4.npz")["res4"]
 

--- a/imgviz/data/voc/__init__.py
+++ b/imgviz/data/voc/__init__.py
@@ -4,6 +4,8 @@ from typing import TypedDict
 import numpy as np
 from numpy.typing import NDArray
 
+from .. import _utils
+
 _here: pathlib.Path = pathlib.Path(__file__).parent
 
 
@@ -20,14 +22,10 @@ def voc() -> _VocData:
     data_file: pathlib.Path = _here / "data.npz"
     data: dict = dict(np.load(data_file))
 
-    # compose masks to class label image
-    class_label: NDArray[np.int32] = np.full(data["rgb"].shape[:2], 0, dtype=np.int32)
-    for label_id, mask in zip(data["labels"], data["masks"]):
-        class_label[mask == 1] = label_id
-
-    names_file: pathlib.Path = _here / "class_names.txt"
-    with open(names_file) as f:
-        class_names = [name.strip() for name in f]
+    class_label = _utils.compose_class_label(
+        shape=data["rgb"].shape[:2], labels=data["labels"], masks=data["masks"]
+    )
+    class_names = _utils.read_class_names(_here / "class_names.txt")
 
     return _VocData(
         rgb=data["rgb"],


### PR DESCRIPTION
The `arc2017` and `voc` data loaders carried byte-for-byte identical logic for two things: composing per-instance masks into a class-label image, and reading the newline-delimited `class_names.txt`. This extracts both into a new internal `imgviz/data/_utils.py` (`compose_class_label`, `read_class_names`), consumed module-qualified (`from .. import _utils`) to match the convention used by every other `_utils` consumer in the codebase.

No behavior change and no public API change: `_utils.py` is not re-exported from `imgviz/data/__init__.py`, and both loaders return identical `class_label`/`class_names` output. Internal-only, so no CHANGELOG entry.

## Test plan
- [x] `uv run --all-extras pytest` (475 passed)
- [x] `make lint` (ruff format/check, ty all clean)
- [x] Smoke: `imgviz.data.voc()` and `imgviz.data.arc2017()` produce the same `class_label` shape/dtype/values and `class_names` as before
