### PR TITLE
fix(nchannel): validate output dtype before fitting/caching PCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Nchannel2Rgb` fitting and caching a PCA before validating the output `dtype`, so a failed call with an invalid `dtype` no longer poisons the cached PCA for later valid calls ([#236](https://github.com/wkentaro/imgviz/pull/236))
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))

--- a/imgviz/_nchannel.py
+++ b/imgviz/_nchannel.py
@@ -59,6 +59,8 @@ class Nchannel2Rgb:
             raise ValueError(
                 f"nchannel.dtype must be floating, but got {nchannel.dtype}"
             )
+        if dtype != np.uint8 and not np.issubdtype(dtype, np.floating):
+            raise ValueError(f"dtype must be floating, but got {dtype}")
         H, W, D = nchannel.shape
 
         dst = nchannel.reshape(-1, D)
@@ -79,8 +81,6 @@ class Nchannel2Rgb:
             dst = normalize(dst, min_value, max_value)
             dst = (dst * 255).round().astype(np.uint8)
         else:
-            if not np.issubdtype(dtype, np.floating):
-                raise ValueError(f"dtype must be floating, but got {dtype}")
             dst = dst.astype(dtype)
 
         return dst

--- a/tests/unit/_nchannel_test.py
+++ b/tests/unit/_nchannel_test.py
@@ -37,6 +37,21 @@ def test_nchannel2rgb_rejects_invalid_output_dtype(
         imgviz.nchannel2rgb(nchannel, dtype=np.int32)  # type: ignore[call-overload]
 
 
+def test_Nchannel2Rgb_invalid_dtype_does_not_fit_pca(
+    nchannel: NDArray[np.float32],
+) -> None:
+    converter = imgviz.Nchannel2Rgb()
+
+    with pytest.raises(ValueError, match="dtype must be floating"):
+        converter(nchannel, dtype=np.int32)  # type: ignore[call-overload]
+
+    assert converter.pca is None
+
+    out = converter(nchannel)
+    out_fresh = imgviz.nchannel2rgb(nchannel)
+    np.testing.assert_array_equal(out, out_fresh)
+
+
 def test_nchannel2rgb_is_deterministic(nchannel: NDArray[np.float32]) -> None:
     out1 = imgviz.nchannel2rgb(nchannel)
     out2 = imgviz.nchannel2rgb(nchannel)


### PR DESCRIPTION
`Nchannel2Rgb.__call__` validated the output `dtype` only *after* fitting and
caching the PCA. So a call with an invalid `dtype` (e.g. `np.int32`) raised, but
left the instance holding a PCA fit on that call's data. A later valid call then
silently reused this poisoned PCA instead of fitting fresh, contradicting the
fit-on-first-call contract.

The fix hoists the `dtype` guard up alongside the existing input checks, before
any PCA fit or cache write, mirroring the eager-validation idiom the sibling
converters already use.

## Test plan
- [x] `test_Nchannel2Rgb_invalid_dtype_does_not_fit_pca` — a rejected `dtype` leaves `converter.pca is None`, and a subsequent valid call matches a fresh converter's output
- [x] `uv run --extra all pytest -n=auto tests` (477 passed)
- [x] `make lint` (ruff format/check, ty, mdformat)
