### PR TITLE
test(fill): cover Fill copy semantics and Stripe empty-mask path

### DIFF
--- a/tests/unit/fill_test.py
+++ b/tests/unit/fill_test.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+import imgviz
+
+_COLOR_RED: tuple[int, int, int] = (255, 0, 0)
+
+
+@pytest.fixture
+def image() -> NDArray[np.uint8]:
+    return np.zeros((10, 10, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def mask() -> NDArray[np.bool_]:
+    mask = np.zeros((10, 10), dtype=bool)
+    mask[2:8, 2:8] = True
+    return mask
+
+
+@pytest.fixture
+def empty_mask() -> NDArray[np.bool_]:
+    return np.zeros((10, 10), dtype=bool)
+
+
+def test_solid_returns_new_array_when_copy_true(
+    image: NDArray[np.uint8], mask: NDArray[np.bool_]
+) -> None:
+    original = image.copy()
+
+    result = imgviz.fill.Solid(color=_COLOR_RED)(mask=mask, image=image, copy=True)
+
+    assert not np.shares_memory(result, image)
+    np.testing.assert_array_equal(image, original)
+    assert (result[mask] == _COLOR_RED).all()
+
+
+def test_solid_mutates_input_when_copy_false(
+    image: NDArray[np.uint8], mask: NDArray[np.bool_]
+) -> None:
+    result = imgviz.fill.Solid(color=_COLOR_RED)(mask=mask, image=image, copy=False)
+
+    assert result is image
+    assert (image[mask] == _COLOR_RED).all()
+
+
+def test_stripe_empty_mask_returns_copy_when_copy_true(
+    image: NDArray[np.uint8], empty_mask: NDArray[np.bool_]
+) -> None:
+    result = imgviz.fill.Stripe(color=_COLOR_RED)(
+        mask=empty_mask, image=image, copy=True
+    )
+
+    assert not np.shares_memory(result, image)
+    np.testing.assert_array_equal(result, image)
+
+
+def test_stripe_empty_mask_returns_input_when_copy_false(
+    image: NDArray[np.uint8], empty_mask: NDArray[np.bool_]
+) -> None:
+    result = imgviz.fill.Stripe(color=_COLOR_RED)(
+        mask=empty_mask, image=image, copy=False
+    )
+
+    assert result is image


### PR DESCRIPTION
`mask2rgb` always calls the fill with `copy=False` after pre-copying the image
itself (`imgviz/_masks.py:46`), so the existing tests never exercise the public
`Fill` objects' own `copy=True` path or `Stripe`'s empty-mask early return. This
adds a dedicated `tests/unit/fill_test.py` that calls `Solid`/`Stripe` directly
to pin those behaviors: `copy=True` returns a fresh array (input untouched),
`copy=False` mutates in place, and `Stripe` short-circuits on an empty mask.

`fill.py` coverage: 93% -> 98% (the one remaining line is the abstract
`Fill.__call__` body).

## Test plan
- [x] `uv run --extra all pytest tests/unit/fill_test.py` (4 passed)
- [x] `uv run --extra all ruff format --check` / `ruff check` / `ty check` clean
