### PR TITLE
fix: round random unlabeled-pixel colors in label2rgb instead of truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `label2rgb` truncating instead of rounding the random colors it assigns to unlabeled (`label < 0`) pixels, which biased those pixels down by up to one per channel ([#239](https://github.com/wkentaro/imgviz/pull/239))
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))

--- a/imgviz/_label.py
+++ b/imgviz/_label.py
@@ -77,7 +77,7 @@ def label2rgb(
     random_state = np.random.RandomState(seed=1234)
 
     mask_unlabeled = label < 0
-    res[mask_unlabeled] = random_state.rand(*(mask_unlabeled.sum(), 3)) * 255
+    res[mask_unlabeled] = (random_state.rand(*(mask_unlabeled.sum(), 3)) * 255).round()
 
     unique_labels = np.unique(label)
     max_label_id = max(int(unique_labels[-1]), 0)

--- a/tests/unit/_label_test.py
+++ b/tests/unit/_label_test.py
@@ -78,6 +78,16 @@ def test_label2rgb_all_unlabeled() -> None:
     assert labelviz.shape == (8, 8, 3)
 
 
+def test_label2rgb_unlabeled_colors_are_rounded() -> None:
+    label = np.full((4, 4), -1, dtype=np.int32)
+    labelviz = imgviz.label2rgb(label=label)
+
+    random_state = np.random.RandomState(seed=1234)
+    expected = (random_state.rand(label.size, 3) * 255).round().astype(np.uint8)
+
+    np.testing.assert_array_equal(labelviz.reshape(-1, 3), expected)
+
+
 def test_label_colormap_is_cached_and_readonly() -> None:
     cmap = imgviz.label_colormap()
     assert cmap.shape == (256, 3)


### PR DESCRIPTION
`label2rgb` assigns random RGB colors to unlabeled (`label < 0`) pixels by writing `rand() * 255` floats straight into a `uint8` array, which truncates toward zero instead of rounding. That biases every unlabeled pixel down by up to one per channel. This is the same truncate-vs-round bug class already fixed for `components.legend` in #223; the fix rounds before the cast, matching the image-blend path two lines below (`_label.py:103`).

## Test plan
- [x] Added regression test `tests/unit/_label_test.py::test_label2rgb_unlabeled_colors_are_rounded` (fails on `main`, passes with the fix)
- [x] `make lint` and `make test` green
- [x] Drove `imgviz.label2rgb` end-to-end: an all-unlabeled label goes from `[48,158,111]` (base, truncated) to `[49,159,112]` (rounded); labeled pixels and the no-unlabeled path are byte-identical to base
