### PR TITLE
fix(tile): clamp auto grid to at least one row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `tile` hanging forever on an extreme tall/narrow aspect ratio, where the auto grid rounded to 0 rows and the layout loop never terminated ([#240](https://github.com/wkentaro/imgviz/pull/240))
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))

--- a/imgviz/_tile.py
+++ b/imgviz/_tile.py
@@ -50,7 +50,7 @@ def _tile(
 
 
 def _get_tile_shape(num: int, hw_ratio: float = 1) -> tuple[int, int]:
-    r_num = int(round(math.sqrt(num / hw_ratio)))  # weighted by wh_ratio
+    r_num = max(1, int(round(math.sqrt(num / hw_ratio))))  # weighted by wh_ratio
     c_num = 0
     while r_num * c_num < num:
         c_num += 1

--- a/tests/unit/_tile_test.py
+++ b/tests/unit/_tile_test.py
@@ -85,6 +85,14 @@ def test_tile_auto_shape_shrinks_redundant_row() -> None:
     assert tiled.shape == (20, 40, 3)  # 2x2, not a wasteful 3x2 (30, 40, 3)
 
 
+def test_tile_auto_shape_handles_tall_narrow_image() -> None:
+    tall = np.zeros((100, 10, 3), dtype=np.uint8)
+
+    tiled = imgviz.tile([tall])  # extreme h:w ratio must not round the grid to 0 rows
+
+    assert tiled.shape == (100, 10, 3)
+
+
 @pytest.mark.parametrize(("row", "col"), [(0, None), (None, 0), (-1, None), (None, -1)])
 def test_tile_rejects_non_positive_row_col(
     images: list[NDArray[np.uint8]], row: int | None, col: int | None


### PR DESCRIPTION
`imgviz.tile` hung forever on an extreme tall/narrow aspect ratio. In
`_get_tile_shape`, the auto grid rows come from `round(sqrt(num / hw_ratio))`;
for a single 100x10 image `hw_ratio` is 10, so this rounds to 0 rows. The layout
loop `while r_num * c_num < num: c_num += 1` then never terminates because
`r_num * c_num` stays pinned at 0. Clamping `r_num` to at least 1 fixes it.

## Test plan
- [x] Added `test_tile_auto_shape_handles_tall_narrow_image` reproducing the hang (fails/hangs before, passes after)
- [x] `uv run --extra all pytest -n=auto tests` — 478 passed
- [x] `ruff format --check` / `ruff check` / `ty check` clean
- [x] Behavioral smoke: `imgviz.tile([np.zeros((100,10,3),np.uint8)])` returns `(100,10,3)` instantly; a 6-image tall batch tiles to `(100,60,3)`; square grids unchanged
