### PR TITLE
test(diff): cover diff shape-rejection guard for unsupported inputs

### DIFF
--- a/tests/unit/_diff_test.py
+++ b/tests/unit/_diff_test.py
@@ -278,3 +278,12 @@ def test_diff_ssim_all_nan_inputs(a_all_nan: bool, b_all_nan: bool) -> None:
     assert out.shape == (*shape, 3)
     assert out.dtype == np.uint8
     np.testing.assert_array_equal(out, np.zeros_like(out))
+
+
+@pytest.mark.parametrize("shape", [(4,), (4, 4, 2), (4, 4, 5)])
+def test_diff_rejects_unsupported_shape(shape: tuple[int, ...]) -> None:
+    a = np.zeros(shape, dtype=np.float32)
+    b = np.zeros(shape, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="image must be"):
+        imgviz.diff(a, b)


### PR DESCRIPTION
`imgviz.diff` reduces color images to luminance via `_to_luminance`, which
rejects any input that is not `(H, W)`, `(H, W, 3)`, or `(H, W, 4)`. That
shape-rejection guard was the only uncovered line in `imgviz/_diff.py`; this
adds a parametrized test that exercises it through the public `diff()` entry
point for a 1-D input and 3-D inputs whose channel count falls on either side
of the valid `{3, 4}` range.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_diff_test.py` (33 passed)
- [x] `uv run --extra all ruff check tests/unit/_diff_test.py` and `ruff format --check`
- [x] `uv run --extra all ty check`
- [x] coverage: `imgviz/_diff.py` shape guard (line 19) now covered
