### PR TITLE
fix(letterbox): clamp resized dimensions to at least one pixel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `letterbox` crashing with an opaque backend assertion when an extreme aspect ratio rounded the internally resized width or height down to 0 pixels, by clamping the resized dimensions to at least 1 pixel ([#242](https://github.com/wkentaro/imgviz/pull/242))
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))

--- a/imgviz/_letterbox.py
+++ b/imgviz/_letterbox.py
@@ -74,8 +74,8 @@ def letterbox(
     scale = min(1.0 * height / image_h, 1.0 * width / image_w)
     image = resize(
         image,
-        height=int(round(image_h * scale)),
-        width=int(round(image_w * scale)),
+        height=max(1, int(round(image_h * scale))),
+        width=max(1, int(round(image_w * scale))),
         interpolation=interpolation,
     )
 

--- a/tests/unit/_letterbox_test.py
+++ b/tests/unit/_letterbox_test.py
@@ -42,6 +42,17 @@ def test_letterbox_portrait_to_square() -> None:
     np.testing.assert_allclose(dst[:, 5:-5], img)
 
 
+@pytest.mark.parametrize("shape", [(100, 3, 3), (3, 100, 3)])
+def test_letterbox_extreme_aspect_ratio_keeps_at_least_one_pixel(
+    shape: tuple[int, int, int],
+) -> None:
+    img = np.zeros(shape, dtype=np.uint8)
+
+    dst = imgviz.letterbox(img, height=1, width=1)  # a dimension would round to 0
+    assert dst.shape == (1, 1, 3)
+    assert dst.dtype == img.dtype
+
+
 def test_letterbox_grayscale_hw() -> None:
     img = np.random.uniform(0, 255, size=(15, 25)).round().astype(np.uint8)
 


### PR DESCRIPTION
`letterbox` fits an image into a target box by scaling it to preserve aspect ratio, then padding. For an extreme aspect ratio the scaled dimension could round down to 0 pixels (e.g. `letterbox(np.zeros((100, 3, 3)), height=1, width=1)` scales width `3 -> round(0.03) = 0`), and the resize backend then raised an opaque assertion (`cv2.error: ... inv_scale_x > 0`) instead of returning an image. This clamps the resized width and height to at least 1 pixel, matching the `max(1, ...)` idiom already used in `_pixelate.py` and proposed in #240 for the analogous tile-grid case.

Scope note: this fixes the aspect-ratio-rounding path in `letterbox` only. The underlying `resize()` can still round a float scale to a 0-sized dimension (e.g. `resize(img, width=0.01)`), and a non-positive *target* `height`/`width` still surfaces a downstream `pad` error; both are pre-existing and left for a separate decision (clamp vs. raise is a genuine design choice there).

## Test plan
- [x] Added `test_letterbox_extreme_aspect_ratio_keeps_at_least_one_pixel`, parametrized over both the width- and height-rounds-to-0 branches; fails on `main` with the OpenCV assertion, passes here.
- [x] `uv run --extra all pytest` (478 passed)
- [x] `make lint` equivalents: `ruff format --check`, `ruff check`, `ty check`, `mdformat --check`, `typos` all clean
