### PR TITLE
test(data): cover lena bundled-image loader

### DIFF
--- a/tests/unit/data/lena_test.py
+++ b/tests/unit/data/lena_test.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+import imgviz
+
+
+def test_lena() -> None:
+    image = imgviz.data.lena()
+    assert image.dtype == np.uint8
+    assert image.shape == (512, 512, 3)


### PR DESCRIPTION
`imgviz.data.lena()` was the one bundled-data loader without a test (its sibling loaders `arc2017` and `voc` are already covered), leaving `imgviz/data/lena/__init__.py` at 70% coverage. This adds a smoke test asserting the loader returns the expected `uint8` `(512, 512, 3)` image, mirroring the existing `tests/unit/data/arc2017_test.py` convention and bringing the module to 100%.

## Test plan
- [x] `uv run --extra all python -m pytest tests/unit/data/lena_test.py` passes
- [x] full suite green (477 passed), `ruff` and `ty` clean