### PR TITLE
test: cover pad non-int border TypeError guard

### DIFF
--- a/tests/unit/_pad_test.py
+++ b/tests/unit/_pad_test.py
@@ -90,6 +90,13 @@ def test_pad_negative_border_raises() -> None:
         imgviz.pad(image, top=-1)
 
 
+def test_pad_non_int_border_raises() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    with pytest.raises(TypeError, match="top must be int, but got float"):
+        imgviz.pad(image, top=1.5)  # ty: ignore[invalid-argument-type]
+
+
 def test_pad_invalid_ndim_raises() -> None:
     image = np.zeros((4,), dtype=np.uint8)
 


### PR DESCRIPTION
`pad()` validates each border argument with `isinstance(value, numbers.Integral)`
before the `value < 0` check, but no test exercised the non-integral branch, so
the `TypeError` guard was uncovered on `main`. This adds a test passing a float
border and asserting the raise, mirroring the adjacent `test_pad_negative_border_raises`.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_pad_test.py` (13 passed)
- [x] `make lint`
