### PR TITLE
fix: round instances2rgb blended mask colors instead of truncating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `instances2rgb` truncating blended mask colors toward zero instead of rounding, so blended mask pixels are no longer biased down by up to one, matching the rounding used by `mask2rgb` and the other blend helpers ([#247](https://github.com/wkentaro/imgviz/pull/247))
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))

--- a/imgviz/_instances.py
+++ b/imgviz/_instances.py
@@ -112,7 +112,8 @@ def instances2rgb(
 
         maskviz = mask[:, :, None] * color_ins.astype(float)
         dst = dst.copy()
-        dst[mask] = (1 - alpha) * image[mask].astype(float) + alpha * maskviz[mask]
+        blended = (1 - alpha) * image[mask].astype(float) + alpha * maskviz[mask]
+        dst[mask] = blended.round().astype(np.uint8)
 
         if boundary_width > 0:
             try:

--- a/tests/unit/_instances_test.py
+++ b/tests/unit/_instances_test.py
@@ -73,6 +73,20 @@ def test_instances2rgb_blends_masks(
     np.testing.assert_array_equal(out[0, 0], image[0, 0])
 
 
+def test_instances2rgb_rounds_blended_mask_colors() -> None:
+    image = np.full((100, 100, 3), 50, dtype=np.uint8)
+    mask = np.zeros((100, 100), dtype=bool)
+    mask[10:90, 10:90] = True
+    colormap = np.array([[0, 0, 0], [99, 99, 99]], dtype=np.uint8)
+
+    out = imgviz.instances2rgb(
+        image=image, labels=[0], masks=[mask], alpha=0.3, colormap=colormap
+    )
+
+    # 0.7 * 50 + 0.3 * 99 = 64.7 -> rounds to 65, not truncated to 64.
+    np.testing.assert_array_equal(out[50, 50], [65, 65, 65])
+
+
 def test_instances2rgb_draws_captions(
     image: NDArray[np.uint8], bbox: list[float]
 ) -> None:


### PR DESCRIPTION
`instances2rgb` assigned the float alpha-blend directly into the `uint8`
destination (`dst[mask] = (1 - alpha) * image[mask] + alpha * maskviz[mask]`),
and numpy's cast truncates toward zero. Every blended mask pixel was therefore
biased down by up to one and diverged from `mask2rgb` / `fill._blend`, which
`.round()` before casting. This rounds first so the overlays match the rounding
the other blend helpers already use (same class of fix as #223 for `legend`).

## Test plan
- [x] `test_instances2rgb_rounds_blended_mask_colors` asserts an exact blended
      pixel (`0.7*50 + 0.3*99 = 64.7` -> `65`, not truncated `64`); it fails on
      the old code and passes on the fix
- [x] `uv run --extra all pytest -n=auto tests` (477 passed)
- [x] `make lint` (ruff format/check + ty)
