### PR TITLE
test(data): cover middlebury read_flow invalid .flo magic guard

### DIFF
--- a/tests/unit/data/middlebury_test.py
+++ b/tests/unit/data/middlebury_test.py
@@ -1,0 +1,14 @@
+import pathlib
+
+import numpy as np
+import pytest
+
+from imgviz.data.middlebury import read_flow
+
+
+def test_read_flow_rejects_invalid_magic(tmp_path: pathlib.Path) -> None:
+    flow_file = tmp_path / "invalid.flo"
+    np.array([1.0], dtype=np.float32).tofile(flow_file)
+
+    with pytest.raises(OSError, match="invalid .flo file"):
+        read_flow(flow_file)


### PR DESCRIPTION
`read_flow` (Middlebury `.flo` reader) raises `OSError` when a file's leading
magic number is not `202021.25`, but that guard had no test — only the happy
path was exercised indirectly via `imgviz.data.middlebury()`. This adds a direct
test that writes a corrupt `.flo` file and asserts the rejection, taking
`imgviz/data/middlebury/__init__.py` to 100% line coverage.

## Test plan
- [x] `uv run pytest tests/unit/data/middlebury_test.py -q`
- [x] `uv run ruff check` / `uv run ty check` on the new file