### PR TITLE
fix: reject NaN input in float2ubyte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 /*.egg-info/
 /.mypy_cache/
 /build/
+/.coverage
 
 # Sphinx
 /docs/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `float2ubyte` silently accepting `NaN`, which defeated the `[0, 1]` range guards (since `NaN` compares false against both bounds) and produced garbage output; it now raises a clear `ValueError` ([#249](https://github.com/wkentaro/imgviz/pull/249))
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))

--- a/imgviz/_dtype.py
+++ b/imgviz/_dtype.py
@@ -15,6 +15,8 @@ def float2ubyte(image: NDArray[np.floating]) -> NDArray[np.uint8]:
     """Convert float image in [0, 1] to uint8."""
     if not np.issubdtype(image.dtype, np.floating):
         raise ValueError(f"image dtype must be float, but got {image.dtype}")
+    if np.isnan(image).any():
+        raise ValueError("image must not contain NaN")
     if image.min() < 0:
         raise ValueError(f"image.min() must be >= 0, but got {image.min()}")
     if image.max() > 1:

--- a/tests/unit/_dtype_test.py
+++ b/tests/unit/_dtype_test.py
@@ -39,3 +39,13 @@ def test_float2ubyte_rejects_below_zero() -> None:
 def test_float2ubyte_rejects_above_one() -> None:
     with pytest.raises(ValueError, match=r"image\.max\(\) must be <= 1"):
         imgviz.float2ubyte(np.array([0.5, 1.1], dtype=np.float32))
+
+
+def test_float2ubyte_rejects_nan() -> None:
+    with pytest.raises(ValueError, match="image must not contain NaN"):
+        imgviz.float2ubyte(np.array([np.nan, 0.5], dtype=np.float32))
+
+
+def test_float2ubyte_nan_does_not_bypass_range_guard() -> None:
+    with pytest.raises(ValueError, match="image must not contain NaN"):
+        imgviz.float2ubyte(np.array([np.nan, -5.0], dtype=np.float32))


### PR DESCRIPTION
`float2ubyte` documents float input in `[0, 1]` and guards the range with
`image.min() < 0` and `image.max() > 1`. `NaN` compares `False` against both
bounds, so any `NaN` slipped past the guards and produced garbage `uint8` output
(with a numpy "invalid value encountered in cast" warning). Worse, a single
`NaN` anywhere also masked genuinely out-of-range values, since `min()`/`max()`
propagate `NaN` — e.g. `float2ubyte([nan, -5.0])` returned `[0, 5]` instead of
raising. This adds an explicit `NaN` check before the range guards so such input
raises a clear `ValueError`, consistent with the adjacent dtype and range
guards.

A second, self-contained commit gitignores the `.coverage` artifact so local
`pytest --cov` runs no longer leave a stray untracked file.

## Test plan
- [x] `tests/unit/_dtype_test.py`: added `test_float2ubyte_rejects_nan` and `test_float2ubyte_nan_does_not_bypass_range_guard`
- [x] `uv run --extra all pytest -q` (478 passed)
- [x] `uv run ruff check .` and `uv run ty check .`
