### PR TITLE
refactor(draw): extract shared as_yx_points validation

### DIFF
--- a/imgviz/draw/_ink.py
+++ b/imgviz/draw/_ink.py
@@ -3,6 +3,7 @@ from typing import TypeAlias
 
 import numpy as np
 import PIL.Image
+from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
 Ink: TypeAlias = (
@@ -23,6 +24,15 @@ def get_pil_ink(
             tuple(int(c) for c in ink.tolist()),
         )
     return ink
+
+
+def as_yx_points(yx: ArrayLike) -> NDArray:
+    yx = np.asarray(yx)
+    if yx.ndim != 2:
+        raise ValueError(f"yx must be 2D array, but got {yx.ndim}D")
+    if yx.shape[1] != 2:
+        raise ValueError(f"yx.shape[1] must be 2, but got {yx.shape[1]}")
+    return yx
 
 
 def require_fill_or_outline(fill: Ink | None, outline: Ink | None) -> None:

--- a/imgviz/draw/_line.py
+++ b/imgviz/draw/_line.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import as_yx_points
 from ._ink import get_pil_ink
 from ._ink import require_pil_image
 
@@ -47,11 +48,7 @@ def line_(
         width: Line width.
     """
     require_pil_image(image=image)
-    yx = np.asarray(yx)
-    if yx.ndim != 2:
-        raise ValueError(f"yx must be 2D array, but got {yx.ndim}D")
-    if yx.shape[1] != 2:
-        raise ValueError(f"yx.shape[1] must be 2, but got {yx.shape[1]}")
+    yx = as_yx_points(yx)
 
     draw = PIL.ImageDraw.Draw(image)
 

--- a/imgviz/draw/_polygon.py
+++ b/imgviz/draw/_polygon.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import as_yx_points
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
 from ._ink import require_pil_image
@@ -55,11 +56,7 @@ def polygon_(
     """
     require_pil_image(image=image)
     require_fill_or_outline(fill, outline)
-    yx = np.asarray(yx)
-    if yx.ndim != 2:
-        raise ValueError(f"yx must be 2D array, but got {yx.ndim}D")
-    if yx.shape[1] != 2:
-        raise ValueError(f"yx.shape[1] must be 2, but got {yx.shape[1]}")
+    yx = as_yx_points(yx)
     if yx.shape[0] < 3:
         raise ValueError(f"yx must have at least 3 vertices, but got {yx.shape[0]}")
 


### PR DESCRIPTION
`draw.line_` and `draw.polygon_` each carried a byte-identical block that
coerced and validated the `yx` points array (`np.asarray` then a `ndim != 2`
guard and a `shape[1] != 2` guard, with the same error messages). This extracts
that block into a shared `as_yx_points()` helper in `imgviz/draw/_ink.py`, which
already hosts the shared draw validators (`require_pil_image`,
`require_fill_or_outline`). Both call sites now delegate to it.

No behavior change: the error messages are preserved verbatim, and `polygon_`
keeps its extra "at least 3 vertices" check inline.

## Test plan
- [x] existing guard tests in `tests/unit/draw/_line_test.py` and
      `tests/unit/draw/_polygon_test.py` still pass (both `yx must be 2D` and
      `yx.shape[1] must be 2` branches)
- [x] `make test` (476 passed)
- [x] `make lint` (ruff + ty clean)
