### PR TITLE
fix: text_in_rectangle over-pads bottom when text overflows both edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
+- Fixed `draw.text_in_rectangle` over-padding the bottom of the grown canvas when text overflowed both the top and bottom edges, because the bottom pad was measured against the pre-top-pad height ([#251](https://github.com/wkentaro/imgviz/pull/251))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))
 

--- a/imgviz/draw/_text_in_rectangle.py
+++ b/imgviz/draw/_text_in_rectangle.py
@@ -134,6 +134,7 @@ def text_in_rectangle(
             dst = _pad.pad(image=dst, top=pad, color=background)
             y1 += pad
             y2 += pad
+            height += pad
         if y2 > height:
             pad = y2 - height
             dst = _pad.pad(image=dst, bottom=pad, color=background)

--- a/tests/unit/draw/_text_in_rectangle_test.py
+++ b/tests/unit/draw/_text_in_rectangle_test.py
@@ -86,6 +86,27 @@ def test_text_in_rectangle_pads_with_full_background_color(
     np.testing.assert_array_equal(res[corner, -1], background)
 
 
+def test_text_in_rectangle_grows_canvas_tightly_when_overflowing_both_ends() -> None:
+    # yx2 above the top edge (y1 < 0) with text tall enough to also overflow the
+    # bottom makes both pad branches fire; the bottom pad must be measured
+    # against the already-top-padded height, not the original one.
+    image = np.full((10, 100, 3), 255, dtype=np.uint8)
+    yx1 = (0, 0)
+    yx2 = (-5, 99)
+
+    aabb = imgviz.draw.text_in_rectangle_aabb(
+        yx1=yx1, yx2=yx2, loc="lb-", text="Hi", size=40
+    )
+    assert aabb.y1 < 0 and aabb.y2 > image.shape[0]
+
+    res = imgviz.draw.text_in_rectangle(
+        image, loc="lb-", text="Hi", size=40, background=(255, 0, 0), yx1=yx1, yx2=yx2
+    )
+
+    assert res.shape[0] == aabb.y2 - aabb.y1
+    assert res.shape[1] == image.shape[1]
+
+
 def test_text_in_rectangle_keep_size_preserves_shape(
     small_image: NDArray[np.uint8],
 ) -> None:


### PR DESCRIPTION
`draw.text_in_rectangle` grows the canvas when the text box overflows the image edges. When it overflows *both* the top and bottom at once, the top pad shifts `y2` down but `height` was left at the original value, so the bottom pad was computed against the pre-top-pad height and over-padded the bottom by exactly the top-pad amount, leaving extra blank rows below the rectangle. Keeping `height` in sync after the top pad fixes it.

## Test plan
- [x] `test_text_in_rectangle_grows_canvas_tightly_when_overflowing_both_ends` (fails on `main` with 44 vs 39, passes here)
- [x] `make lint` and full `pytest` (477 passed)
