### PR TITLE
fix: measure multi-line text height with Pillow layout in draw.text_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `draw.text_size` undercounting the height of multi-line text, which sized `draw.text_in_rectangle` and other labels too short so glyphs rendered outside the background, by measuring with Pillow's own multi-line layout ([#252](https://github.com/wkentaro/imgviz/pull/252))
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))

--- a/imgviz/draw/_text.py
+++ b/imgviz/draw/_text.py
@@ -1,3 +1,4 @@
+import math
 import pathlib
 
 import numpy as np
@@ -40,17 +41,10 @@ def text_size(
     """
     font = _get_font(size, font_path=font_path)
 
-    text_width = 0
-    text_height = 0
-    for line in text.splitlines():
-        if line == "":
-            line = "\n"
+    draw = PIL.ImageDraw.Draw(PIL.Image.new("RGB", (1, 1)))
+    _, _, text_width, text_height = draw.multiline_textbbox((0, 0), text, font=font)
 
-        line_width, line_height = font.getbbox(line)[2:]
-        text_width = max(text_width, line_width)
-        text_height += line_height
-
-    return text_height, text_width
+    return math.ceil(text_height), math.ceil(text_width)
 
 
 def text(

--- a/tests/unit/draw/_text_test.py
+++ b/tests/unit/draw/_text_test.py
@@ -23,3 +23,18 @@ def test_text_size_blank_line_adds_height() -> None:
     height_without, _ = imgviz.draw.text_size("a\nb", size=20)
     height_with, _ = imgviz.draw.text_size("a\n\nb", size=20)
     assert height_with > height_without
+
+
+def test_text_size_encloses_rendered_multiline_text() -> None:
+    text = "Hello\nWorld\nFoo"
+    height, width = imgviz.draw.text_size(text, size=20)
+
+    canvas = np.full((height + 50, width + 50, 3), 255, dtype=np.uint8)
+    rendered = imgviz.draw.text(canvas, yx=(0, 0), text=text, size=20)
+
+    # The reported size must enclose the rendered glyphs. Anti-aliased ink can
+    # just touch the final row/column, so allow equality; the multi-line
+    # undercount this guards shrinks the box by many pixels, not one.
+    rows, cols = np.where((rendered != 255).any(axis=2))
+    assert rows.max() <= height
+    assert cols.max() <= width


### PR DESCRIPTION
`draw.text_size` summed each line's own bounding-box height to measure multi-line
text, but Pillow lays lines out on a fixed pitch with inter-line spacing. The
result undercounted multi-line height, so `draw.text_in_rectangle` (and the
`label2rgb` / `scalebar` / `legend` labels that call it) sized their background
rectangle too short and lower lines rendered outside it. Measuring with Pillow's
own `multiline_textbbox` — the same layout `draw.text` uses to render — makes the
reported size match what actually gets drawn. Single-line output is unchanged;
`math.ceil` keeps the result an integer that never rounds below the true extent.

## Test plan
- [x] `test_text_size_encloses_rendered_multiline_text` renders multi-line text and asserts every glyph pixel falls within the reported size (fails under the old undercount, passes now)
- [x] `uv run python -m pytest` (477 passed) and `make lint` (ruff + ty) green
