### PR TITLE
perf(instances): compute mask bbox with per-axis reductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sped up `masks_to_bboxes` (and `instances2rgb` when derived from masks) by computing each tight bounding box from per-axis reductions instead of materializing every foreground pixel's coordinates ([#253](https://github.com/wkentaro/imgviz/pull/253))
 - Documented that `label2rgb`, `instances2rgb`, and `flags2rgb` accept a grayscale `(H, W)` image in addition to `(H, W, 3)`, matching the input they already convert internally ([#232](https://github.com/wkentaro/imgviz/pull/232))
 - Changed `rgb2hsv` and `hsv2rgb` to validate input shape and dtype and raise a clear `ValueError`, matching the other color converters, instead of surfacing a confusing error from Pillow ([#222](https://github.com/wkentaro/imgviz/pull/222))
 

--- a/imgviz/_instances.py
+++ b/imgviz/_instances.py
@@ -26,12 +26,13 @@ def masks_to_bboxes(
     """
     bboxes = np.zeros((len(masks), 4), dtype=float)
     for i, mask in enumerate(masks):
-        if mask.sum() == 0:
+        rows = np.flatnonzero(np.any(mask, axis=1))
+        if rows.size == 0:
             continue
-        where = np.argwhere(mask)
-        (ymin, xmin), (ymax, xmax) = where.min(axis=0), where.max(axis=0)
-        bbox = ymin, xmin, ymax, xmax
-        bboxes[i] = bbox
+        cols = np.flatnonzero(np.any(mask, axis=0))
+        ymin, ymax = rows[0], rows[-1]
+        xmin, xmax = cols[0], cols[-1]
+        bboxes[i] = ymin, xmin, ymax, xmax
     return bboxes
 
 


### PR DESCRIPTION
`masks_to_bboxes` built each tight bounding box with `np.argwhere`, which
materializes a coordinate array for every foreground pixel, then took its
min/max, on top of a separate `mask.sum()` scan just to skip empty masks. This
reduces each mask to per-row and per-column "any" flags and reads the first and
last set index, so the cost no longer scales with the number of foreground
pixels and the emptiness check reuses that same reduction.

Output is unchanged for boolean masks (the documented `(N, H, W)` contract).
`instances2rgb` benefits when called with `masks` and no `bboxes`, since it
derives the boxes through this function.

## Note

The old `argwhere` unpacking incidentally raised `ValueError` on a non-2D mask;
the per-axis reduction does not, so a non-2D mask (already outside the
documented 2D-per-mask contract) now yields a wrong box instead of crashing. I
did not add an explicit `ndim` guard, to keep the change surgical. Flagging it
in case you'd prefer an explicit shape check.

## Test plan
- [x] Existing `tests/unit/_instances_test.py` (incl. empty-mask and arc2017 multi-instance cases) pass unchanged
- [x] Full suite green: `uv run --extra all pytest -n=auto tests` (476 passed)
- [x] 300+ randomized differential cases confirm bit-identical output vs the old `argwhere` implementation
- [x] `make lint` clean (ruff, ty)
- [x] Smoke: `instances2rgb` via the masks path renders on `imgviz.data.arc2017()`
