### PR TITLE
refactor: extract shared compute_corner_origin block-placement helper

### DIFF
--- a/imgviz/_scalebar.py
+++ b/imgviz/_scalebar.py
@@ -8,6 +8,7 @@ import cmap as _cmap
 import numpy as np
 from numpy.typing import NDArray
 
+from . import _utils
 from . import draw as draw_module
 from ._color import get_fg_color
 
@@ -90,8 +91,12 @@ def scalebar(
 
     block_width = max(bar_length, label_width)
     block_height = label_height + gap + bar_thickness
-    x0 = width - margin - block_width if loc in ("rt", "rb") else margin
-    y0 = height - margin - block_height if loc in ("lb", "rb") else margin
+    y0, x0 = _utils.compute_corner_origin(
+        container_size=(height, width),
+        block_size=(block_height, block_width),
+        loc=loc,
+        margin=margin,
+    )
 
     if isinstance(color, str) and color == "auto":
         region = image[max(0, y0) : y0 + block_height, max(0, x0) : x0 + block_width]

--- a/imgviz/_utils.py
+++ b/imgviz/_utils.py
@@ -1,8 +1,30 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 import PIL.Image
 from numpy.typing import NDArray
+
+
+def compute_corner_origin(
+    container_size: tuple[int, int],
+    block_size: tuple[int, int],
+    loc: Literal["lt", "rt", "lb", "rb"],
+    margin: int,
+) -> tuple[int, int]:
+    """Top-left origin (y0, x0) for placing a block in a container corner.
+
+    Places a block of ``block_size`` inside a ``container_size`` region, offset
+    by ``margin`` from the corner selected by ``loc`` ("lt", "rt", "lb", "rb").
+    """
+    if loc not in ("lt", "rt", "lb", "rb"):
+        raise ValueError(f"unsupported loc: {loc}")
+    height, width = container_size
+    block_height, block_width = block_size
+    y0 = margin if loc in ("lt", "rt") else height - margin - block_height
+    x0 = margin if loc in ("lt", "lb") else width - margin - block_width
+    return y0, x0
 
 
 def pillow_to_numpy(image: PIL.Image.Image) -> NDArray[np.uint8]:

--- a/imgviz/components/_legend.py
+++ b/imgviz/components/_legend.py
@@ -78,20 +78,14 @@ def legend_(
     legend_width = text_width + text_height + 2 * pad
 
     width, height = image.size
-    if loc == "rb":
-        yx2 = np.array([height - pad, width - pad], dtype=float)
-        yx1 = yx2 - (legend_height, legend_width)
-    elif loc == "lt":
-        yx1 = np.array([pad, pad], dtype=float)
-        yx2 = yx1 + (legend_height, legend_width)
-    elif loc == "rt":
-        yx1 = np.array([pad, width - pad - legend_width], dtype=float)
-        yx2 = yx1 + (legend_height, legend_width)
-    elif loc == "lb":
-        yx2 = np.array([height - pad, pad + legend_width], dtype=float)
-        yx1 = yx2 - (legend_height, legend_width)
-    else:
-        raise ValueError(f"unsupported loc: {loc}")
+    y0, x0 = _utils.compute_corner_origin(
+        container_size=(height, width),
+        block_size=(legend_height, legend_width),
+        loc=loc,
+        margin=pad,
+    )
+    yx1 = np.array([y0, x0], dtype=float)
+    yx2 = yx1 + (legend_height, legend_width)
 
     alpha = 0.5
     y1, x1 = yx1.round().astype(int)

--- a/tests/unit/_utils_test.py
+++ b/tests/unit/_utils_test.py
@@ -39,3 +39,35 @@ def test_apply_mask_rejects_shape_mismatch() -> None:
 
     with pytest.raises(ValueError, match="mask.shape must be"):
         _utils.apply_mask(image=image, transformed=image, mask=mask)
+
+
+@pytest.mark.parametrize(
+    ("loc", "expected"),
+    [
+        ("lt", (5, 5)),
+        ("rt", (5, 100 - 5 - 30)),
+        ("lb", (100 - 5 - 20, 5)),
+        ("rb", (100 - 5 - 20, 100 - 5 - 30)),
+    ],
+)
+def test_compute_corner_origin_places_in_each_corner(
+    loc: str, expected: tuple[int, int]
+) -> None:
+    origin = _utils.compute_corner_origin(
+        container_size=(100, 100),
+        block_size=(20, 30),
+        loc=loc,  # type: ignore[arg-type]
+        margin=5,
+    )
+
+    assert origin == expected
+
+
+def test_compute_corner_origin_rejects_unsupported_loc() -> None:
+    with pytest.raises(ValueError, match="unsupported loc"):
+        _utils.compute_corner_origin(
+            container_size=(100, 100),
+            block_size=(20, 30),
+            loc="middle",  # type: ignore[arg-type]
+            margin=5,
+        )


### PR DESCRIPTION
`scalebar()` and `legend_()` each computed, inline, the top-left origin for
placing a block of a given size in one of four container corners (`lt`/`rt`/`lb`/`rb`)
offset by a margin. The two expressions were the same arithmetic written two
different ways. Fold them into one `imgviz._utils.compute_corner_origin` helper.
The extraction is byte-identical: the derived `(y0, x0)` is unchanged for every
corner at both call sites, and `legend_`'s `"unsupported loc"` guard is preserved
inside the helper.

## Test plan
- [x] added `tests/unit/_utils_test.py` for `compute_corner_origin` (four corners + invalid-loc guard)
- [x] existing per-corner rendering tests still pass (`_scalebar_test.py`, `components/_legend_test.py`)
- [x] `make lint` and full `pytest` green (481 passed)
