### PR TITLE
perf(normalize): compute densely and let NaN propagate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sped up `normalize` by computing over the whole array and letting NaN propagate through the arithmetic instead of gathering and scattering the non-NaN pixels through a boolean mask, giving a bit-identical result with roughly a 2-3x speedup on large images ([#257](https://github.com/wkentaro/imgviz/pull/257))
 - Documented that `label2rgb`, `instances2rgb`, and `flags2rgb` accept a grayscale `(H, W)` image in addition to `(H, W, 3)`, matching the input they already convert internally ([#232](https://github.com/wkentaro/imgviz/pull/232))
 - Changed `rgb2hsv` and `hsv2rgb` to validate input shape and dtype and raise a clear `ValueError`, matching the other color converters, instead of surfacing a confusing error from Pillow ([#222](https://github.com/wkentaro/imgviz/pull/222))
 

--- a/imgviz/_normalize.py
+++ b/imgviz/_normalize.py
@@ -77,14 +77,15 @@ def normalize(
     min_value[issame] -= spread
     max_value[issame] += spread
 
-    dst: NDArray[np.float32] = np.zeros(image.shape, dtype=np.float32)
-
-    if image.ndim == 2:
-        isnan = np.isnan(image)
-    else:
+    dst: NDArray[np.float32] = ((image - min_value) / (max_value - min_value)).astype(
+        np.float32, copy=False
+    )
+    # For (H, W) input NaN already propagates through the arithmetic; only the
+    # multichannel case needs to collapse a per-channel NaN across the pixel.
+    if image.ndim == 3:
         isnan = np.isnan(image).any(axis=2)
-    dst[~isnan] = 1.0 * (image[~isnan] - min_value) / (max_value - min_value)
-    dst[isnan] = np.nan
+        if isnan.any():
+            dst[isnan] = np.nan
 
     if return_minmax:
         return dst, min_value, max_value


### PR DESCRIPTION
Sped up `imgviz.normalize` by computing the normalization densely over the whole array and letting IEEE-754 NaN propagation do the masking, instead of allocating a zeros buffer and scattering the result through a boolean mask. For `(H, W)` input the arithmetic already yields NaN wherever the input is NaN, so no overwrite is needed; only the multichannel path still collapses a per-channel NaN across the whole pixel. It also drops a dead `1.0 *` float-promotion factor (subtracting the float32 `min_value` already promotes integer inputs) and uses `astype(..., copy=False)` to skip a full-array copy when the result is already float32.

Output is bit-identical to `main`, verified with `np.array_equal(equal_nan=True)` across 2D/3D, float16/32/64, int, bool, constant (`max == min`), inf, and large-magnitude inputs. Roughly 2-3x faster on the function itself at 1080x1920 (the win is largest on the common no-NaN 2D path).

One nuance for reviewers: because the dense form evaluates arithmetic on pixels the masked path skipped, a pathological input (a fully-NaN-discarded pixel that also holds an inf, or a value that overflows float32 on the cast) can now emit a spurious `RuntimeWarning` under warnings-as-errors that `main` did not. The output values are unchanged, and `normalize` already warns explicitly when min/max are inf. `np.errstate` suppression was deliberately rejected: it would also hide the legitimate overflow warning `main` emits on kept (non-discarded) large pixels.

## Test plan
- [x] `make test` (476 pass, including `-W error::RuntimeWarning`)
- [x] `make lint` (ruff format/check, ty)
- [x] Bit-identity vs `main` verified across dtypes/shapes/NaN/inf/constant/large-magnitude
- [x] Smoke: `normalize` on real `arc2017` depth (NaN preserved, range [0, 1]) and `depth2rgb` downstream (valid RGB)
