### PR TITLE
refactor(draw): delegate circle_ to ellipse_

### DIFF
--- a/imgviz/draw/_circle.py
+++ b/imgviz/draw/_circle.py
@@ -1,12 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
+from ._ellipse import ellipse_
 from ._ink import Ink
-from ._ink import get_pil_ink
-from ._ink import require_fill_or_outline
 
 
 def circle(
@@ -60,21 +58,17 @@ def circle_(
         outline: RGB color to draw the outline.
         width: Line width.
     """
-    require_fill_or_outline(fill, outline)
-
-    draw = PIL.ImageDraw.Draw(image)
-
     cy, cx = center
 
     radius = diameter / 2.0
     x1 = cx - radius
-    x2 = x1 + diameter
     y1 = cy - radius
-    y2 = y1 + diameter
 
-    draw.ellipse(
-        [x1, y1, x2, y2],
-        fill=get_pil_ink(fill),
-        outline=get_pil_ink(outline),
+    ellipse_(
+        image=image,
+        yx1=(y1, x1),
+        yx2=(y1 + diameter, x1 + diameter),
+        fill=fill,
+        outline=outline,
         width=width,
     )


### PR DESCRIPTION
A circle is an equal-axis ellipse, and `circle_` duplicated the guard,
`get_pil_ink` conversion, and `PIL.ImageDraw.Draw(...).ellipse(...)` call that
`ellipse_` already implements. It now computes the bounding-box corners and
delegates to `ellipse_`, dropping the now-unused imports. The arithmetic is
preserved exactly (`x1 = cx - radius`, `yx2 = (y1 + diameter, x1 + diameter)`),
so output is bit-identical.

## Test plan
- [x] `tests/unit/draw/_circle_test.py` and `_ellipse_test.py` pass unchanged
- [x] Bit-identical vs the previous implementation across fractional centers,
      1px and oversized diameters, fill/outline/width combinations
- [x] `ruff` + `ty` clean
