### PR TITLE
refactor(flow): hoist loop-invariant range mask out of per-channel loop

### DIFF
--- a/imgviz/_flow.py
+++ b/imgviz/_flow.py
@@ -65,18 +65,19 @@ def _flow_compute_color(flow_u: NDArray, flow_v: NDArray) -> NDArray[np.uint8]:
     k1 = k0 + 1
     k1[k1 == ncols] = 1
 
+    in_range = rad <= 1
+    out_range = ~in_range
+
     for i in range(colorwheel.shape[1]):
         tmp = colorwheel[:, i]
         col0 = tmp[k0] / 255.0
         col1 = tmp[k1] / 255.0
         col = (1 - f) * col0 + f * col1
 
-        idx = rad <= 1
-        col[idx] = 1 - rad[idx] * (1 - col[idx])
-        col[~idx] = col[~idx] * 0.75  # out of range?
+        col[in_range] = 1 - rad[in_range] * (1 - col[in_range])
+        col[out_range] = col[out_range] * 0.75
 
-        ch_idx = i
-        flow_image[:, :, ch_idx] = np.floor(255 * col)
+        flow_image[:, :, i] = np.floor(255 * col)
 
     return flow_image
 


### PR DESCRIPTION
In `_flow_compute_color`, the range mask `rad <= 1` (and its complement) is
independent of the per-channel loop, but was recomputed on every one of the
three iterations. Hoist it above the loop, name the two masks for intent
(`in_range` / `out_range`), and drop the dead `ch_idx = i` alias.

Output is byte-identical: `rad`, `in_range`, and `out_range` are never mutated
inside the loop, so this is a pure loop-invariant hoist. Verified equal to
`origin/main` on real Middlebury flow data and on random out-of-range inputs.

## Test plan
- [x] `uv run --extra all python -m pytest -q` (476 passed)
- [x] `uv run ruff check` / `uv run ty check` clean
- [x] byte-identical output vs `origin/main` on middlebury + out-of-range flow
