### PR TITLE
refactor(colorize): collapse dtype overloads with a bound TypeVar

### DIFF
--- a/imgviz/_colorize.py
+++ b/imgviz/_colorize.py
@@ -9,6 +9,8 @@ from numpy.typing import NDArray
 
 from ._normalize import normalize
 
+_FloatT = typing.TypeVar("_FloatT", bound=np.floating)
+
 
 class Colorize:
     """Apply a colormap to a 2D scalar field.
@@ -54,22 +56,8 @@ class Colorize:
     def __call__(
         self,
         scalar: NDArray,
-        dtype: type[np.float32],
-    ) -> NDArray[np.float32]: ...
-
-    @typing.overload
-    def __call__(
-        self,
-        scalar: NDArray,
-        dtype: type[np.float64],
-    ) -> NDArray[np.float64]: ...
-
-    @typing.overload
-    def __call__(
-        self,
-        scalar: NDArray,
-        dtype: type[np.floating],
-    ) -> NDArray[np.floating]: ...
+        dtype: type[_FloatT],
+    ) -> NDArray[_FloatT]: ...
 
     def __call__(
         self, scalar: NDArray, dtype: type[np.uint8] | type[np.floating] = np.uint8
@@ -124,28 +112,8 @@ def colorize(
     vmin: float | NDArray | None = ...,
     vmax: float | NDArray | None = ...,
     cmap: str | Callable[[NDArray], NDArray] = ...,
-    dtype: type[np.float32] = ...,
-) -> NDArray[np.float32]: ...
-
-
-@typing.overload
-def colorize(
-    scalar: NDArray,
-    vmin: float | NDArray | None = ...,
-    vmax: float | NDArray | None = ...,
-    cmap: str | Callable[[NDArray], NDArray] = ...,
-    dtype: type[np.float64] = ...,
-) -> NDArray[np.float64]: ...
-
-
-@typing.overload
-def colorize(
-    scalar: NDArray,
-    vmin: float | NDArray | None = ...,
-    vmax: float | NDArray | None = ...,
-    cmap: str | Callable[[NDArray], NDArray] = ...,
-    dtype: type[np.floating] = ...,
-) -> NDArray[np.floating]: ...
+    dtype: type[_FloatT] = ...,
+) -> NDArray[_FloatT]: ...
 
 
 def colorize(


### PR DESCRIPTION
`Colorize.__call__` and `colorize()` each declared four near-identical
`@overload` stubs (`uint8`, `float32`, `float64`, `floating`). The three concrete
float overloads are subsumed by a single overload parameterized on a `TypeVar`
bound to `np.floating`, which is the idiom already used by the sibling `_tint.py`
and `_colorblind.py`. This removes 32 lines of duplicated type stubs and makes
`_colorize.py` consistent with its neighbours.

The runtime `def` bodies are untouched, so behavior is byte-identical.

## Test plan
- [x] `reveal_type` confirms inference is preserved: `dtype=np.float32` -> `NDArray[float32]`, `dtype=np.float64` -> `NDArray[float64]`, `uint8` default unchanged, on both `colorize()` and `Colorize.__call__`
- [x] `uv run ty check --no-progress` clean
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run pytest -n=auto tests` — 476 passed
