### PR TITLE
perf(blur): blur whole multi-band image in one Pillow pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documented that `label2rgb`, `instances2rgb`, and `flags2rgb` accept a grayscale `(H, W)` image in addition to `(H, W, 3)`, matching the input they already convert internally ([#232](https://github.com/wkentaro/imgviz/pull/232))
 - Changed `rgb2hsv` and `hsv2rgb` to validate input shape and dtype and raise a clear `ValueError`, matching the other color converters, instead of surfacing a confusing error from Pillow ([#222](https://github.com/wkentaro/imgviz/pull/222))
+- Changed `blur` to filter multi-band images in a single Pillow pass instead of channel by channel, speeding up RGB/RGBA blurring with byte-identical output ([#261](https://github.com/wkentaro/imgviz/pull/261))
 
 ### Fixed
 

--- a/imgviz/_blur.py
+++ b/imgviz/_blur.py
@@ -46,17 +46,20 @@ def blur(
 
 
 def _gaussian_blur(image: NDArray, sigma: float) -> NDArray:
-    if image.ndim == 2:
-        return _gaussian_blur_2d(arr=image, sigma=sigma)
+    # Pillow blurs each band independently, so blurring a whole (H, W),
+    # (H, W, 2), (H, W, 3), or (H, W, 4) image in one pass is bit-identical to
+    # blurring band by band. Other channel counts have no Pillow mode, so they
+    # fall back to the per-band loop.
+    if image.ndim == 2 or image.shape[2] in (2, 3, 4):
+        return _gaussian_blur_pil(arr=image, sigma=sigma)
 
-    C = image.shape[2]
     dst = np.empty_like(image)
-    for c in range(C):
-        dst[..., c] = _gaussian_blur_2d(arr=image[..., c], sigma=sigma)
+    for c in range(image.shape[2]):
+        dst[..., c] = _gaussian_blur_pil(arr=image[..., c], sigma=sigma)
     return dst
 
 
-def _gaussian_blur_2d(arr: NDArray, sigma: float) -> NDArray:
+def _gaussian_blur_pil(arr: NDArray, sigma: float) -> NDArray:
     pil = PIL.Image.fromarray(arr)
     blurred = pil.filter(PIL.ImageFilter.GaussianBlur(radius=sigma))
     return np.asarray(blurred)

--- a/tests/unit/_blur_test.py
+++ b/tests/unit/_blur_test.py
@@ -6,8 +6,8 @@ import imgviz
 
 @pytest.mark.parametrize(
     "shape",
-    [(40, 50, 3), (40, 50), (40, 50, 4), (40, 50, 5)],
-    ids=["rgb", "gray", "rgba", "five-channel"],
+    [(40, 50, 3), (40, 50), (40, 50, 2), (40, 50, 4), (40, 50, 5)],
+    ids=["rgb", "gray", "la", "rgba", "five-channel"],
 )
 def test_blur_whole_image(shape: tuple[int, ...]) -> None:
     rng = np.random.default_rng(seed=0)


### PR DESCRIPTION
`_gaussian_blur` looped over channels, running a separate
`fromarray` / `GaussianBlur` / `asarray` round-trip per band. Pillow blurs each
band independently, so blurring the whole `(H, W, 2/3/4)` image in a single pass
produces byte-identical output while dropping the redundant round-trips
(~1.2-1.3x on RGB, ~2x on RGBA). Channel counts Pillow has no mode for
(`C == 1`, `C >= 5`) keep the existing per-band fallback.

## Test plan
- [x] `test_blur_whole_image` extended with a 2-channel (`LA`) case, so all three
      fast-path channel counts (2/3/4) plus 2D and the 5-channel fallback are covered
- [x] `uv run --all-extras pytest -q` (476 passed)
- [x] Verified byte-identical public `imgviz.blur` output vs `origin/main` on a real
      image (RGB, RGBA, gray, and mask-redaction paths all match)
