### PR TITLE
refactor(resize): extract shared _resolve_interpolation helper

### DIFF
--- a/imgviz/_resize.py
+++ b/imgviz/_resize.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Final
+from collections.abc import Mapping
 from typing import Literal
+from typing import TypeVar
 
 import numpy as np
 import PIL.Image
@@ -14,17 +15,27 @@ try:
 except ImportError:
     cv2 = None  # type: ignore[assignment]
 
+_ResampleT = TypeVar("_ResampleT")
+
+
+def _resolve_interpolation(
+    interpolation: Literal["linear", "nearest"], mapping: Mapping[str, _ResampleT]
+) -> _ResampleT:
+    if interpolation not in mapping:
+        raise ValueError(f"unsupported interpolation: {interpolation}")
+    return mapping[interpolation]
+
 
 def _resize_pillow(
     image: NDArray, height: int, width: int, interpolation: Literal["linear", "nearest"]
 ) -> NDArray:
-    resample: Final
-    if interpolation == "linear":
-        resample = PIL.Image.BILINEAR
-    elif interpolation == "nearest":
-        resample = PIL.Image.NEAREST
-    else:
-        raise ValueError(f"unsupported interpolation: {interpolation}")
+    resample = _resolve_interpolation(
+        interpolation,
+        {
+            "linear": PIL.Image.Resampling.BILINEAR,
+            "nearest": PIL.Image.Resampling.NEAREST,
+        },
+    )
 
     if np.issubdtype(image.dtype, np.integer):
         dst = _utils.numpy_to_pillow(image)
@@ -57,13 +68,10 @@ def _resize_opencv(
     if cv2 is None:
         raise ImportError("opencv-python is not installed")
 
-    interpolation_int: int
-    if interpolation == "linear":
-        interpolation_int = cv2.INTER_LINEAR
-    elif interpolation == "nearest":
-        interpolation_int = cv2.INTER_NEAREST
-    else:
-        raise ValueError(f"unsupported interpolation: {interpolation}")
+    interpolation_int = _resolve_interpolation(
+        interpolation,
+        {"linear": cv2.INTER_LINEAR, "nearest": cv2.INTER_NEAREST},
+    )
 
     dst = cv2.resize(image, (width, height), interpolation=interpolation_int)
     return dst


### PR DESCRIPTION
`_resize_pillow` and `_resize_opencv` each mapped the `interpolation` string to
a backend constant with the same `if/elif/else` structure and the same
`"unsupported interpolation"` `ValueError`. This extracts one generic
`_resolve_interpolation(interpolation, mapping)` helper so that validation lives
in a single place, with each backend passing its own constant mapping.

Output is byte-identical. The pillow branch now references the equivalently
valued `PIL.Image.Resampling.BILINEAR`/`NEAREST` enum members instead of the
legacy top-level `PIL.Image.BILINEAR`/`NEAREST` aliases (same int values;
`Pillow>=10.0.0` guarantees `Resampling`) so the extracted generic helper keeps
precise typing under `ty`.

## Test plan
- [x] `make lint` (ruff + `ty check` clean)
- [x] `pytest` (476 passed; existing `test_resize_rejects_unknown_interpolation`
      and `test_resize_preserves_solid_color` cover both backends' success and
      failure paths through the new helper)
- [x] byte-identity: 36 md5 hashes match `origin/main` across dtype × shape ×
      interpolation × backend
