### PR TITLE
test(flags): cover flags2rgb multi-instance per-instance drawing

### DIFF
--- a/tests/unit/_flags_test.py
+++ b/tests/unit/_flags_test.py
@@ -71,6 +71,20 @@ def test_flags2rgb_on_zero_flags_draws_no_pie(black_image: NDArray[np.uint8]) ->
     assert np.array_equal(res[60:140, 60:140], black_image[60:140, 60:140])
 
 
+def test_flags2rgb_draws_each_instance_independently(
+    black_image: NDArray[np.uint8],
+) -> None:
+    res = imgviz.flags2rgb(
+        black_image,
+        flags=np.array([[True, False], [False, False], [False, True]]),
+        centers=np.array([[40.0, 40.0], [40.0, 100.0], [40.0, 160.0]]),
+        flag_names=["broken", "occluded"],
+    )
+    assert np.array_equal(res[40, 40], make_flag_color(0))
+    assert np.array_equal(res[40, 160], make_flag_color(1))
+    assert np.array_equal(res[25:56, 85:116], black_image[25:56, 85:116])
+
+
 def test_flags2rgb_all_draws_off_wedges_gray(black_image: NDArray[np.uint8]) -> None:
     res = imgviz.flags2rgb(
         black_image,


### PR DESCRIPTION
Every functional `flags2rgb` test used a single instance, so the per-instance
loop, its `flags[i, j]` / `centers[i]` indexing and the `if not fills: continue`
skip for an all-false flag row, was never exercised with N>1. A `flags[0, j]`
typo would have passed the entire suite.

This adds one 3-instance case: instance 0 draws flag color 0, instance 1 has no
active flags (skipped, its region must stay untouched), and instance 2 draws
flag color 1. Centers are 60px apart with a 30px diameter, so discs never
overlap and the default bottom-right legend stays clear of the checked pixels.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_flags_test.py -q` (13 passed)
- [x] Mutating the source `flags[i, j]` -> `flags[0, j]` makes the new test fail (has teeth)
- [x] `uv run --extra all pytest -q` (477 passed); `ruff`/`ty` clean
