### PR TITLE
perf(tint): fuse uint8 blend in place to avoid full-size intermediates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sped up `tint` on uint8 images by ~1.6-2.4x by blending in place instead of allocating full-size float64 intermediates, with bit-identical output ([#266](https://github.com/wkentaro/imgviz/pull/266))
 - Documented that `label2rgb`, `instances2rgb`, and `flags2rgb` accept a grayscale `(H, W)` image in addition to `(H, W, 3)`, matching the input they already convert internally ([#232](https://github.com/wkentaro/imgviz/pull/232))
 - Changed `rgb2hsv` and `hsv2rgb` to validate input shape and dtype and raise a clear `ValueError`, matching the other color converters, instead of surfacing a confusing error from Pillow ([#222](https://github.com/wkentaro/imgviz/pull/222))
 

--- a/imgviz/_tint.py
+++ b/imgviz/_tint.py
@@ -57,7 +57,10 @@ def tint(image: NDArray, color: _cmap.ColorLike, alpha: float = 0.3) -> NDArray:
 
     rgba = _cmap.Color(color).rgba if is_float else _cmap.Color(color).rgba8
     solid = np.array(rgba[:3], dtype=np.float64)
-    blended = (1 - alpha) * image + alpha * solid
     if is_float:
-        return blended.astype(image.dtype)
-    return blended.round().astype(np.uint8)
+        return ((1 - alpha) * image + alpha * solid).astype(image.dtype)
+    blended = image.astype(np.float64)
+    blended *= 1 - alpha
+    blended += alpha * solid
+    np.round(blended, out=blended)
+    return blended.astype(np.uint8)

--- a/tests/unit/_tint_test.py
+++ b/tests/unit/_tint_test.py
@@ -44,6 +44,25 @@ def test_tint_float(dtype: type[np.floating]) -> None:
     assert np.array_equal(imgviz.tint(img, "red", alpha=0.0), img)
 
 
+def test_tint_uint8_blends_expected_values() -> None:
+    img = np.arange(48, dtype=np.uint8).reshape(4, 4, 3)
+    color = (200, 50, 100)
+    alpha = 0.3
+    solid = np.array(color, dtype=np.float64)
+    expected = np.round((1 - alpha) * img.astype(np.float64) + alpha * solid)
+    res = imgviz.tint(img, color, alpha=alpha)
+    assert np.array_equal(res, expected.astype(np.uint8))
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.float32])
+def test_tint_does_not_mutate_input(dtype: type[np.generic]) -> None:
+    high = 255 if dtype == np.uint8 else 1
+    img = (np.random.rand(10, 10, 3) * high).astype(dtype)
+    original = img.copy()
+    imgviz.tint(img, "red", alpha=0.5)
+    assert np.array_equal(img, original)
+
+
 def test_tint_rejects_non_rgb() -> None:
     with pytest.raises(ValueError, match="must be RGB"):
         imgviz.tint(np.zeros((10, 10), dtype=np.uint8), "red")


### PR DESCRIPTION
## Summary
- `tint()`'s uint8 path built the wash as `(1 - alpha) * image + alpha * solid`, allocating three full-size float64 intermediates before rounding and casting back to uint8. It now blends in place on a single float64 buffer (`*=`, `+=`, `np.round(out=)`), roughly halving large-array memory traffic.
- Output is bit-identical to before: same float64 promotion, same single final rounding, and the same memory layout (verified across uint8/float16/float32/float64, C- and F-ordered inputs, all alphas, and an exhaustive uint8 value sweep — zero mismatches).
- The float path is left as the original expression on purpose: its in-place variant is only a marginal, size-dependent win and can regress at thumbnail sizes (the documented use case), so it is not worth the readability cost.
- Measured ~1.6-2.4x on the uint8 path from 480x640 up to 2000x2000.

## Test plan
- [x] `test_tint_uint8_blends_expected_values` pins the exact blended output at `alpha=0.3` (mutation-tested: catches an operand-order swap the boundary-alpha tests miss)
- [x] `test_tint_does_not_mutate_input` locks that `tint()` never mutates the caller's array
- [x] `make lint` (ruff + ty) and full `pytest` (479 passed)
