### PR TITLE
refactor(masks): extract shared require_bool_mask validation helper

### DIFF
--- a/imgviz/_masks.py
+++ b/imgviz/_masks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 from numpy.typing import NDArray
 
+from . import _utils
 from ._color import asrgb
 from .fill import Fill
 from .fill import Solid
@@ -31,8 +32,7 @@ def mask2rgb(
     """
     if mask.ndim != 2:
         raise ValueError(f"mask.ndim must be 2, got {mask.ndim}")
-    if mask.dtype != np.bool_:
-        raise ValueError(f"mask.dtype must be bool, got {mask.dtype}")
+    _utils.require_bool_mask(mask)
     if not isinstance(fill, Fill):
         fill = Solid(color=fill)
 

--- a/imgviz/_utils.py
+++ b/imgviz/_utils.py
@@ -19,6 +19,12 @@ def numpy_to_pillow(image: NDArray, mode: str | None = None) -> PIL.Image.Image:
     return image_pillow
 
 
+def require_bool_mask(mask: NDArray) -> None:
+    """Raise ValueError unless mask has bool dtype."""
+    if mask.dtype != np.bool_:
+        raise ValueError(f"mask.dtype must be bool, got {mask.dtype}")
+
+
 def apply_mask(
     image: NDArray,
     transformed: NDArray,
@@ -32,8 +38,7 @@ def apply_mask(
     """
     if mask is None:
         return transformed
-    if mask.dtype != np.bool_:
-        raise ValueError(f"mask.dtype must be bool, got {mask.dtype}")
+    require_bool_mask(mask)
     if mask.shape != image.shape[:2]:
         raise ValueError(f"mask.shape must be {image.shape[:2]}, got {mask.shape}")
 


### PR DESCRIPTION
The identical bool-dtype guard (`if mask.dtype != np.bool_: raise ValueError(f"mask.dtype must be bool, got {mask.dtype}")`) lived in both `_utils.apply_mask` and `_masks.mask2rgb`. Extract it into one `_utils.require_bool_mask` helper and call it from both sites.

The condition, error type, message text, and check order are all unchanged (in `mask2rgb` the `ndim != 2` check still runs first; in `apply_mask` the `mask is None` short-circuit still runs first), so behavior is byte-identical. Superficially similar bool-mask guards in `_flags.py`/`_dtype.py`/`_label.py` use different messages and are deliberately left untouched (folding them in would be a public error-message change, not a dedup).

No CHANGELOG entry: pure refactor/dedup, per repo precedent (#255, #256).

## Test plan
- [x] `uv run --extra all pytest -n=auto tests` — 476 passed (both error paths locked by `test_apply_mask_rejects_non_bool_mask` and `test_mask2rgb_rejects_non_bool`)
- [x] `make lint` (ruff format/check + ty) clean
