### PR TITLE
test(draw): assert star and triangle vertex geometry

### DIFF
--- a/tests/unit/draw/_star_test.py
+++ b/tests/unit/draw/_star_test.py
@@ -12,6 +12,18 @@ def test_star() -> None:
     assert not np.array_equal(res, img)
 
 
+def test_star_spikes_are_solid_with_empty_notches() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    res = imgviz.draw.star(img, center=(50, 50), size=60, fill=(255, 0, 0))
+    filled = np.all(res == (255, 0, 0), axis=2)
+    # the top spike is filled solid, from its tip straight down through the center
+    assert filled[22:51, 50].all()
+    # a notch-free blob (e.g. a decagon) would fill these flanking points;
+    # the star's concave notches leave them empty
+    assert not filled[32, 37]
+    assert not filled[32, 63]
+
+
 def test_star_rejects_missing_fill_and_outline() -> None:
     img = np.full((100, 100, 3), 255, dtype=np.uint8)
     with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):

--- a/tests/unit/draw/_triangle_test.py
+++ b/tests/unit/draw/_triangle_test.py
@@ -12,6 +12,17 @@ def test_triangle() -> None:
     assert not np.array_equal(res, img)
 
 
+def test_triangle_apex_points_up() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    res = imgviz.draw.triangle(img, center=(50, 50), size=60, fill=(255, 0, 0))
+    filled = np.all(res == (255, 0, 0), axis=2)
+    # a single apex at the top center, widening into a flat base at the bottom
+    assert filled[22, 45:56].any()
+    assert filled[25].sum() < filled[60].sum()
+    # the base is the bottom edge; nothing extends below it
+    assert not filled[67, 45:56].any()
+
+
 def test_triangle_rejects_missing_fill_and_outline() -> None:
     img = np.full((100, 100, 3), 255, dtype=np.uint8)
     with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):


### PR DESCRIPTION
The existing `star` and `triangle` tests only checked that the output shape and
dtype are preserved and that some pixel changed, leaving the vertex-placement
math unverified: a sign or angle-offset error in either primitive passed the
whole suite (confirmed by source mutation).

Add geometry assertions that pin the shape down:

- `triangle`: the apex sits at the top center and widens into a flat base at the
  bottom, with nothing below it (catches an apex-up vs apex-down offset, e.g.
  `+90` -> `+30` in the vertex angle).
- `star`: the top spike is filled solid from its tip straight down through the
  center, while the flanking points stay empty where a notch-free blob would
  fill them (catches a valley-vertex angle sign flip).

Both new tests were mutation-proven to fail when the corresponding vertex math
is broken, and pass on the current source.

## Test plan
- [x] `pytest tests/unit` (478 passed)
- [x] mutation check: `triangle` `+90`->`+30` and `star` valley `+pi/5`->`-pi/5`
      each fail the new test, pass after revert
- [x] `make lint` (ruff + ty clean on the touched files)
