### PR TITLE
test(label): pin label_colormap known color values

### DIFF
--- a/tests/unit/_label_test.py
+++ b/tests/unit/_label_test.py
@@ -87,6 +87,17 @@ def test_label_colormap_is_cached_and_readonly() -> None:
         cmap[0] = (1, 2, 3)
 
 
+def test_label_colormap_matches_known_values() -> None:
+    cmap = imgviz.label_colormap()
+    np.testing.assert_array_equal(cmap[0], (0, 0, 0))
+    np.testing.assert_array_equal(cmap[1], (128, 0, 0))
+    np.testing.assert_array_equal(cmap[2], (0, 128, 0))
+    np.testing.assert_array_equal(cmap[3], (128, 128, 0))
+    np.testing.assert_array_equal(cmap[4], (0, 0, 128))
+    np.testing.assert_array_equal(cmap[9], (192, 0, 0))
+    np.testing.assert_array_equal(cmap[255], (224, 224, 192))
+
+
 def test_label2rgb_casts_bool_label() -> None:
     label = np.array([[True, False], [False, True]], dtype=bool)
 


### PR DESCRIPTION
`label_colormap()` builds the PASCAL-VOC colors via `np.unpackbits` / bit-shift
math, but the only existing test (`test_label_colormap_is_cached_and_readonly`)
checked shape, dtype, caching, and read-only-ness, never a single color value. A
wrong channel assignment (`_bitget(i, 0)` vs `_bitget(i, 1)`) or a wrong
bit-shift stride (`np.arange(0, 24, 3)`) would still produce a valid-looking
`(256, 3)` uint8 map and pass the whole suite.

This pins the canonical first colors (0-4), a multi-bit index (9 -> `(192, 0, 0)`)
that exercises the shift accumulation, and the fully accumulated last index
(255 -> `(224, 224, 192)`), locking the channel and shift arithmetic.

## Test plan
- [x] `make test` (477 passed)
- [x] mutation-proven: R/G channel swap (`_bitget(i, 0)` -> `_bitget(i, 1)`) and
  shift-stride change (`arange(0, 24, 3)` -> `arange(0, 16, 2)`) each fail the new
  test; both pass on revert
- [x] `make lint` (ruff + ty clean)
