### PR TITLE
test(draw): assert pie center is interpreted as (cy, cx)

### DIFF
--- a/tests/unit/draw/_pie_test.py
+++ b/tests/unit/draw/_pie_test.py
@@ -49,6 +49,22 @@ def test_pie_single_fill_colors_disc(white_image: NDArray[np.uint8]) -> None:
     assert tuple(res[cy, cx]) == fill
 
 
+def test_pie_center_is_yx_not_xy() -> None:
+    # Non-square image with an asymmetric center, so a (cy, cx) -> (cx, cy)
+    # swap moves the disc to a distinguishable location instead of being
+    # masked by a square image / symmetric center.
+    image = np.full((150, 250, 3), 255, dtype=np.uint8)
+    center = (50, 120)
+    fill = (255, 0, 0)
+    res = imgviz.draw.pie(image, center=center, diameter=40, fills=[fill])
+    cy, cx = center
+    # The true (cy, cx) center is inside the disc.
+    assert tuple(res[cy, cx]) == fill
+    # The transposed (cx, cy) location, where a swap would place the disc, is
+    # far enough that a correctly placed disc cannot reach it.
+    assert tuple(res[cx, cy]) == (255, 255, 255)
+
+
 def test_pie_three_wedges_distinct_colors(white_image: NDArray[np.uint8]) -> None:
     # Three equal wedges (120 deg each) clockwise from 12 o'clock:
     #   Wedge 0 (red):   0-120  deg from 12 -- midpoint at  60 deg (upper-right)


### PR DESCRIPTION
Every existing `imgviz.draw.pie` test drives a square image with a symmetric
center `(100, 100)`, so a `(cy, cx)` -> `(cx, cy)` swap in the bbox produces
byte-identical output and goes unverified. This adds one regression test on a
non-square `(150, 250)` image with an asymmetric center `(50, 120)`, so the
disc's placement pins the axis order: the true `(cy, cx)` center is filled and
the transposed location stays untouched.

Mutation-verified: swapping `cy`/`cx` in `_pie.py`'s bbox fails only this new
test while the other five pass, confirming the gap and the test's teeth.

## Test plan
- [x] `uv run --extra all pytest tests/unit/draw/_pie_test.py` (6 passed)
- [x] full suite green (477 passed), `ruff` + `ty` clean
