### PR TITLE
test(draw): assert line points are (y, x) not (x, y)

### DIFF
--- a/tests/unit/draw/_line_test.py
+++ b/tests/unit/draw/_line_test.py
@@ -18,6 +18,14 @@ def test_line(white_image: NDArray[np.uint8]) -> None:
     assert (res[50, 50] == (0, 0, 0)).all()  # line lands on the diagonal
 
 
+def test_line_points_are_yx_not_xy(white_image: NDArray[np.uint8]) -> None:
+    # Vertical segment at column x=80; a (y, x) -> (x, y) swap would instead
+    # draw it horizontally at row y=80.
+    res = imgviz.draw.line(white_image, yx=[(10, 80), (90, 80)], fill=(0, 0, 0))
+    assert (res[50, 80] == (0, 0, 0)).all()  # on the vertical line
+    assert (res[80, 50] == (255, 255, 255)).all()  # reflected point stays white
+
+
 def test_line_underscore_mutates_in_place(white_image: NDArray[np.uint8]) -> None:
     image = PIL.Image.fromarray(white_image)
 


### PR DESCRIPTION
Every existing `draw.line` test drove diagonal points `(10,10) -> (90,90)` and
sampled the on-diagonal pixel `res[50,50]`, so the `yx[:, ::-1]` swap in
`_line.py` that converts `(y, x)` to Pillow's `(x, y)` was a no-op under the
fixtures and went unverified. A dropped or misapplied axis swap would pass the
whole suite.

`test_line_points_are_yx_not_xy` draws a vertical segment at column `x=80` and
asserts an on-line pixel is filled while its transposed reflection stays clear,
so a `(y, x) <-> (x, y)` swap fails deterministically. Mutation-checked: removing
the `[:, ::-1]` reversal fails only this new test; the other six stay green.

Complements (does not conflict with) #250: that PR refactors `_line.py`'s input
validation but preserves the `yx[:, ::-1]` swap this test guards, and it does not
touch `tests/unit/draw/_line_test.py`. This test would protect that refactor.

## Test plan
- [x] `uv run --extra all pytest` (477 passed)
- [x] `make lint` clean on the diff (`ruff format`, `ruff check`, `ty`)
- [x] mutation-proven: `xy = yx[:, ::-1]` -> `xy = yx` fails only the new test
