### PR TITLE
refactor(draw): use require_pil_image helper in arrow_

### DIFF
--- a/imgviz/draw/_arrow.py
+++ b/imgviz/draw/_arrow.py
@@ -7,6 +7,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_pil_image
 
 
 def arrow(
@@ -65,10 +66,7 @@ def arrow_(
         head_length_ratio: Arrowhead length as a fraction of the shaft length.
         head_angle: Half-angle of the arrowhead in degrees.
     """
-    if not isinstance(image, PIL.Image.Image):
-        raise TypeError(
-            f"image must be PIL.Image.Image, but got {type(image).__name__}"
-        )
+    require_pil_image(image=image)
     tail = np.asarray(yx1, dtype=float)
     tip = np.asarray(yx2, dtype=float)
     if tail.shape != (2,):


### PR DESCRIPTION
`arrow_` reinvented the `require_pil_image` type guard inline instead of calling
the shared helper in `imgviz/draw/_ink.py` that `line_` and `polygon_` already
use. Fold it into the helper so `arrow_` becomes the third caller. Byte-identical:
same `TypeError`, same message text, same position (first check, before the
`yx1`/`yx2` shape validation).

This is a pure dedup, distinct from #208 (which adds the guard to primitives that
never had it, a behavior change); `arrow_` already validated.

## Test plan
- [x] `test_arrow_rejects_non_pil_image` locks the `TypeError` message, unchanged
- [x] `ruff check`, `ty check`, full suite (476 passed) green
