### PR TITLE
test(draw): assert rectangle corners are (y, x) not (x, y)

### DIFF
--- a/tests/unit/draw/_rectangle_test.py
+++ b/tests/unit/draw/_rectangle_test.py
@@ -11,6 +11,13 @@ def test_rectangle() -> None:
     assert res.dtype == img.dtype
 
 
+def test_rectangle_corners_are_yx_not_xy() -> None:
+    img = np.full((80, 80, 3), 255, dtype=np.uint8)
+    res = imgviz.draw.rectangle(img, yx1=(10, 20), yx2=(30, 60), fill=(0, 0, 0))
+    assert tuple(res[20, 40]) == (0, 0, 0)
+    assert tuple(res[40, 25]) == (255, 255, 255)
+
+
 def test_rectangle_rejects_missing_fill_and_outline() -> None:
     img = np.full((100, 100, 3), 255, dtype=np.uint8)
     with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):


### PR DESCRIPTION
`draw.rectangle`'s only prior test asserted `shape`/`dtype` on a square canvas
with a diagonal box `(0,0)-(50,50)`, so the `(y,x) -> (x,y)` reversal in
`rectangle_` (`imgviz/draw/_rectangle.py:67-70`) was never verified: a dropped
or misapplied axis swap passed the whole suite. This adds
`test_rectangle_corners_are_yx_not_xy`, which fills an asymmetric off-diagonal
box (`yx1=(10,20)`, `yx2=(30,60)`) and probes one point inside the true box and
one point that would only be filled under a swapped interpretation, so both
assertions independently flip if the axis order regresses.

Same axis-order regression-test family as the recent siblings
`test_pie_center_is_yx_not_xy` (#270) and `test_line_points_are_yx_not_xy`
(#271). No CHANGELOG entry (test-only, not user-facing).

## Test plan
- [x] `uv run --extra all pytest` — 477 passed
- [x] mutation-proven: swapping `xy=(x1, y1, x2, y2)` -> `xy=(y1, x1, y2, x2)` fails only the new test; passes on revert
- [x] `make lint` (ruff format/check, ty) clean on the change
