### PR TITLE
test(draw): assert rounded_rectangle corners are (y, x) not (x, y)

### DIFF
--- a/tests/unit/draw/_rounded_rectangle_test.py
+++ b/tests/unit/draw/_rounded_rectangle_test.py
@@ -37,6 +37,20 @@ def test_rounded_rectangle_clips_the_corners(white_image: NDArray[np.uint8]) -> 
     np.testing.assert_array_equal(res[50, 50], [0, 0, 0])
 
 
+def test_rounded_rectangle_corners_are_yx_not_xy(
+    white_image: NDArray[np.uint8],
+) -> None:
+    # non-square, off-diagonal box so a (y, x) -> (x, y) swap moves the fill
+    res = imgviz.draw.rounded_rectangle(
+        white_image, (20, 40), (60, 95), radius=10, fill=(0, 0, 0)
+    )
+
+    # interior of the true box (rows 20-60, cols 40-95); white if axes swap
+    np.testing.assert_array_equal(res[25, 80], [0, 0, 0])
+    # interior of the swapped box only (rows 40-95, cols 20-60); black if axes swap
+    np.testing.assert_array_equal(res[90, 30], [255, 255, 255])
+
+
 def test_rounded_rectangle_in_place_mutates_pil_image() -> None:
     image = PIL.Image.new("RGB", (100, 100), (255, 255, 255))
     before = np.asarray(image).copy()


### PR DESCRIPTION
Every prior `rounded_rectangle` test used a symmetric box (`(10,10)-(90,90)`,
`(0,0)-(50,50)`), so the `(y, x) -> PIL (x, y)` reversal in
`_rounded_rectangle.py` (`xy=(x1, y1, x2, y2)`) was never verified: swapping it
to `xy=(y1, x1, y2, x2)` passes the whole suite. This adds a non-square,
off-diagonal box with two interior probes that each flip independently under the
swap, closing the axis-order gap (same family as #268/#270/#271/#273 for the
other draw primitives).

## Test plan
- [x] `test_rounded_rectangle_corners_are_yx_not_xy` passes on clean source
- [x] mutation-proven: `xy=(x1,y1,x2,y2)` -> `xy=(y1,x1,y2,x2)` fails only the new test (other 4 pass), passes on revert
- [x] full suite green (477 passed), `ruff` + `ty` clean
