### PR TITLE
test(draw): assert rotated_rectangle center is (cy, cx) not (cx, cy)

### DIFF
--- a/tests/unit/draw/_rotated_rectangle_test.py
+++ b/tests/unit/draw/_rotated_rectangle_test.py
@@ -123,6 +123,20 @@ def test_rotated_rectangle_preserves_area_under_rotation(
     assert abs(area_upright - area_tilted) / area_upright < 0.05
 
 
+def test_rotated_rectangle_center_is_yx_not_xy(
+    black_image: NDArray[np.uint8],
+) -> None:
+    # asymmetric center so a (cy, cx) <-> (cx, cy) swap moves the rectangle
+    center = (20, 70)
+    res = imgviz.draw.rotated_rectangle(
+        black_image, center=center, size=(10, 10), angle=0, fill=(255, 255, 255)
+    )
+
+    cy, cx = center
+    np.testing.assert_array_equal(res[cy, cx], [255, 255, 255])
+    np.testing.assert_array_equal(res[cx, cy], [0, 0, 0])
+
+
 def test_rotated_rectangle_in_place_mutates_pil_image() -> None:
     image = PIL.Image.new("RGB", (100, 100), (0, 0, 0))
     before = np.asarray(image).copy()


### PR DESCRIPTION
Every prior `draw.rotated_rectangle` test uses the symmetric `center=(50, 50)`,
so the `(cy, cx)` center axis order was never verified: swapping the
`+ (cx, cy)` translation in `_rotated_rectangle.py` to `+ (cy, cx)` would move
the rectangle yet pass the whole suite. This adds one regression test with an
asymmetric `center=(20, 70)` that probes the true center (filled) and its
transpose (unfilled), so a swap flips both assertions.

Mutation-verified teeth (per the repo's stale-`.pyc` guard: cleared
`__pycache__` + `--reinstall-package`): `+ (cx, cy)` -> `+ (cy, cx)` fails only
this test and passes on revert. Same axis-order coverage class as #268-#274.

## Test plan
- [x] `uv run --extra all pytest tests/unit/draw/_rotated_rectangle_test.py` (10 passed)
- [x] full suite green (477 passed), `ruff check`, `ty check`
