### PR TITLE
test(draw): cover box_corners per-axis tick-length clamp

### DIFF
--- a/tests/unit/draw/_box_corners_test.py
+++ b/tests/unit/draw/_box_corners_test.py
@@ -47,6 +47,16 @@ def test_box_corners_degrades_to_rectangle_when_length_exceeds_box(
     assert np.array_equal(res[20, 50], [0, 255, 0])  # top edge now fully drawn
 
 
+def test_box_corners_clamps_tick_length_per_axis() -> None:
+    img = np.full((120, 70, 3), 255, dtype=np.uint8)
+    # tall 100x20 box with length between the two axis extents
+    res = imgviz.draw.box_corners(
+        img, yx1=(10, 10), yx2=(110, 30), fill=(0, 255, 0), length=50, width=1
+    )
+    assert np.all(res[10, 45] == 255)  # x tick clamps to width 20, stops at x=30
+    assert np.array_equal(res[45, 10], [0, 255, 0])  # y tick keeps length 50
+
+
 def test_box_corners_respects_width(white_image: NDArray[np.uint8]) -> None:
     thin = imgviz.draw.box_corners(
         white_image, yx1=(20, 20), yx2=(80, 80), fill=(0, 255, 0), width=1


### PR DESCRIPTION
`box_corners` clamps its corner tick length per axis (`tick_x = min(length, x2 - x1)`, `tick_y = min(length, y2 - y1)`), so a large `length` degrades to a full rectangle. Every existing test used a square 60x60 box, where `tick_x` and `tick_y` are numerically identical, so a `tick_x`/`tick_y` swap was invisible to the whole suite.

This adds one regression test on a tall 100x20 box with `length=50` between the two axis extents: the x tick clamps to width 20 (so `res[10, 45]` stays blank) while the y tick keeps its full length 50 (so `res[45, 10]` is drawn). Each probe flips independently under a `tick_x`/`tick_y` swap.

## Test plan
- [x] `uv run --extra all pytest tests/unit/draw/_box_corners_test.py` (9 passed)
- [x] mutation-proven: swapping `tick_x`/`tick_y` in `_box_corners.py` fails only the new test; passes on revert
- [x] `ruff format --check` / `ruff check` / `ty check`
