### PR TITLE
test(draw): assert ellipse bbox is (y, x) not (x, y)

### DIFF
--- a/tests/unit/draw/_ellipse_test.py
+++ b/tests/unit/draw/_ellipse_test.py
@@ -12,6 +12,13 @@ def test_ellipse() -> None:
     assert not np.array_equal(res, img)
 
 
+def test_ellipse_bbox_is_yx_not_xy() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    res = imgviz.draw.ellipse(img, yx1=(20, 20), yx2=(80, 60), fill=(0, 255, 0))
+    np.testing.assert_array_equal(res[75, 40], [0, 255, 0])
+    np.testing.assert_array_equal(res[40, 75], [255, 255, 255])
+
+
 def test_ellipse_rejects_missing_fill_and_outline() -> None:
     img = np.full((100, 100, 3), 255, dtype=np.uint8)
     with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):


### PR DESCRIPTION
`draw.ellipse` builds its PIL bounding box as `[x1, y1, x2, y2]` from the `(y, x)`
inputs (`_ellipse.py:63`), but the only prior functional test asserted just
shape/dtype/not-equal, so that axis reversal was never verified by a pixel probe:
dropping or misapplying the swap passed the whole suite.

`test_ellipse_bbox_is_yx_not_xy` renders the existing non-square box
(`yx1=(20,20)`, `yx2=(80,60)`) and probes two points that are transposes of each
other: `res[75, 40]` (inside the true tall ellipse, filled) and `res[40, 75]`
(only inside the transposed ellipse, must stay white). Both assertions flip
independently if the corners are read as `(x, y)`. This is the ellipse counterpart
to the sibling axis-order tests (rectangle / rounded_rectangle / pie / line).

## Test plan
- [x] `uv run --extra all pytest tests/unit/draw/_ellipse_test.py` (3 passed)
- [x] full suite green (477 passed); `ruff` + `ty` clean
- [x] teeth verified: swapping `_ellipse.py:63` to `[y1, x1, y2, x2]` fails only this test (cache cleared + `--reinstall-package`), passes on revert
