### PR TITLE
test(colorblind): pin per-kind dichromacy matrix output values

### DIFF
--- a/tests/unit/_colorblind_test.py
+++ b/tests/unit/_colorblind_test.py
@@ -42,6 +42,18 @@ def test_colorblind_float(dtype: type[np.floating], kind: Kind) -> None:
     assert np.allclose(imgviz.colorblind(gray, kind=kind), gray)
 
 
+@pytest.mark.parametrize("kind", KINDS)
+def test_colorblind_applies_kind_specific_matrix(kind: Kind) -> None:
+    px = np.array([[[200, 130, 60]]], dtype=np.uint8)
+    expected = {
+        "protanopia": [170, 169, 77],
+        "deuteranopia": [174, 179, 81],
+        "tritanopia": [196, 90, 93],
+    }
+    res = imgviz.colorblind(px, kind=kind)
+    np.testing.assert_array_equal(res[0, 0], expected[kind])
+
+
 def test_colorblind_rejects_invalid_kind(rgb: NDArray[np.uint8]) -> None:
     with pytest.raises(ValueError, match="kind must be one of"):
         imgviz.colorblind(rgb, kind="monochromacy")  # type: ignore[arg-type]


### PR DESCRIPTION
`colorblind()`'s existing tests only checked shape, dtype, and no-op-on-gray, so
the mapping from each `kind` to its dichromacy matrix was never verified: any
row-stochastic matrix passes those checks, so a wrong kind→matrix assignment (or
a merge/copy-paste swap of the adjacent matrix literals) would ship silently.

This pins the exact uint8 output for a single probe pixel `[200, 130, 60]` across
all three kinds. The probe exercises all three matrix columns and yields a
distinct value per kind, so any pairwise matrix swap flips at least one
assertion. Verified via source mutation (swapping the protanopia/deuteranopia
matrices fails only the two new cases; the rest of the suite stays green).

## Test plan
- [x] `uv run --extra all pytest -q` (479 passed)
- [x] `make lint` (ruff + ty green)
