### PR TITLE
test(io): verify lblsave writes label_colormap palette colors

### DIFF
--- a/tests/unit/io_test.py
+++ b/tests/unit/io_test.py
@@ -1,6 +1,7 @@
 import pathlib
 
 import numpy as np
+import PIL.Image
 import pytest
 from numpy.typing import NDArray
 
@@ -59,3 +60,16 @@ def test_lblsave(tmp_path: pathlib.Path) -> None:
     label_cls_read = imgviz.io.imread(png_file)
 
     np.testing.assert_array_equal(label_cls, label_cls_read)
+
+
+def test_lblsave_writes_palette_colors(tmp_path: pathlib.Path) -> None:
+    lbl = np.array([[0, 1], [2, 3]], dtype=np.uint8)
+
+    png_file = tmp_path / "label.png"
+    imgviz.io.lblsave(png_file, lbl)
+
+    with PIL.Image.open(png_file) as image:
+        rgb = np.asarray(image.convert("RGB"))
+
+    expected = imgviz.label_colormap()[lbl]
+    np.testing.assert_array_equal(rgb, expected)


### PR DESCRIPTION
`lblsave` writes a paletted PNG using `label_colormap()`, but the only prior
test (`test_lblsave`) round-trips the file through `imgviz.io.imread`, which
returns the raw palette *indices* for a mode-`P` image, never the RGB colors
baked into the palette. So the palette encoding itself (`putpalette(colormap.flatten())`)
was unverified: a reversed or channel-swapped palette would ship wrong colors
on every saved visualization and pass the whole suite.

This adds `test_lblsave_writes_palette_colors`, which reopens the saved PNG,
converts it to RGB, and asserts the pixels equal `label_colormap()[lbl]`. The
2x2 `[[0, 1], [2, 3]]` fixture maps to four distinct colormap rows, so a
reversed palette or an R/B channel swap flips the assertion (both mutations
verified to fail only this test, and to pass on revert).

## Test plan
- [x] `uv run --extra all pytest tests/unit/io_test.py` (8 passed)
- [x] mutation-proven: `colormap.flatten()` -> `colormap[:, ::-1].flatten()` (R/B swap) and `colormap[::-1].flatten()` (reversed) each fail only the new test
- [x] full suite `uv run --extra all pytest` (477 passed), `ruff`, `ty` clean
