### PR TITLE
test(centerize): cover return_mask and interpolation forwarding to letterbox

### DIFF
--- a/tests/unit/_centerize_test.py
+++ b/tests/unit/_centerize_test.py
@@ -38,6 +38,30 @@ def test_centerize_matches_letterbox() -> None:
     np.testing.assert_array_equal(from_centerize, from_letterbox)
 
 
+def test_centerize_forwards_return_mask_and_interpolation() -> None:
+    img = np.random.uniform(0, 255, size=(10, 10, 3)).round().astype(np.uint8)
+
+    with pytest.warns(DeprecationWarning):
+        dst, mask = imgviz.centerize(
+            img,
+            height=20,
+            width=30,
+            cval=0,
+            return_mask=True,
+            interpolation="nearest",
+        )
+    ref, ref_mask = imgviz.letterbox(
+        img,
+        height=20,
+        width=30,
+        color=0,
+        return_mask=True,
+        interpolation="nearest",
+    )
+    np.testing.assert_array_equal(dst, ref)
+    np.testing.assert_array_equal(mask, ref_mask)
+
+
 _Loc: TypeAlias = Literal["center", "lt", "rt", "lb", "rb"]
 
 


### PR DESCRIPTION
The deprecated `imgviz.centerize` shim forwards every argument to `imgviz.letterbox`, but its tests only ever exercised the defaults (`return_mask=False`, `interpolation="linear"`). So the `return_mask` and `interpolation` forwarding went unverified: dropping `return_mask=return_mask` (returning a bare array instead of a `(array, mask)` tuple) or hardcoding `interpolation` both passed the whole suite.

This adds one test that calls `centerize(..., return_mask=True, interpolation="nearest")` on a 10x10 image upscaled to 20x30 (a real resize, so interpolation matters) and asserts both outputs equal `letterbox(...)` called with the same non-default args — reusing the same letterbox-as-oracle idiom as the existing `test_centerize_matches_letterbox`.

Mutation-verified teeth: dropping `return_mask` forwarding breaks the tuple-unpack; `interpolation="nearest"` differs from the default `"linear"` on most pixels at this 2x upscale. Each mutation fails only the new test.

## Test plan
- [x] `uv run --extra all pytest tests/` (477 passed)
- [x] `uv run ruff check` / `ruff format --check` / `uv run --extra all ty check` clean
