### PR TITLE
test(depth): cover min_value/max_value/colormap forwarding to colorize

### DIFF
--- a/tests/unit/_depth_test.py
+++ b/tests/unit/_depth_test.py
@@ -35,6 +35,33 @@ def test_depth2rgb_matches_colorize_with_jet() -> None:
     np.testing.assert_array_equal(legacy, new)
 
 
+def test_depth2rgb_forwards_min_max_colormap_to_colorize() -> None:
+    data = imgviz.data.arc2017()
+
+    with pytest.warns(DeprecationWarning):
+        legacy = imgviz.depth2rgb(
+            data["depth"], min_value=0.5, max_value=1.0, colormap="gray"
+        )
+
+    new = imgviz.colorize(data["depth"], vmin=0.5, vmax=1.0, cmap="gray")
+
+    np.testing.assert_array_equal(legacy, new)
+
+
+def test_Depth2Rgb_forwards_constructor_args() -> None:
+    data = imgviz.data.arc2017()
+
+    with pytest.warns(DeprecationWarning):
+        depth2rgb = imgviz.Depth2Rgb(min_value=0.5, max_value=1.0, colormap="gray")
+
+    assert depth2rgb.min_value == 0.5
+    assert depth2rgb.max_value == 1.0
+
+    new = imgviz.colorize(data["depth"], vmin=0.5, vmax=1.0, cmap="gray")
+
+    np.testing.assert_array_equal(depth2rgb(data["depth"]), new)
+
+
 def test_Depth2Rgb_accepts_depth_kwarg() -> None:
     data = imgviz.data.arc2017()
 


### PR DESCRIPTION
The `depth2rgb` function and `Depth2Rgb` class are deprecated shims that forward
their `min_value`/`max_value`/`colormap` arguments to `imgviz.colorize` (as
`vmin`/`vmax`/`cmap`). All prior tests exercised only the default values, so the
forwarding of those three arguments, and the `Depth2Rgb.min_value`/`max_value`
properties, went unverified: a `vmin`/`vmax` swap or a dropped `cmap` would have
passed the whole suite.

These two tests pass non-default values (`min_value=0.5`, `max_value=1.0`,
`colormap="gray"`) and compare against the equivalent `colorize()` call, and
assert the properties expose the constructor args. Mutation-verified: swapping
`vmin`/`vmax` or dropping `cmap` in `_depth.py` fails only the new tests.

## Test plan
- [x] `uv run --extra all pytest` (478 passed)
- [x] `make lint` (ruff + ty clean on the changed file)
