### PR TITLE
test(flow): pin flow2rgb cardinal-direction colorwheel colors

### DIFF
--- a/tests/unit/_flow_test.py
+++ b/tests/unit/_flow_test.py
@@ -51,6 +51,28 @@ def test_flow2rgb_handles_negative_zero_v() -> None:
     np.testing.assert_array_equal(flow_viz, imgviz.flow2rgb(flow_pos))
 
 
+@pytest.mark.parametrize(
+    ("uv", "expected_rgb"),
+    [
+        pytest.param((1.0, 0.0), (255, 17, 0), id="+u"),
+        pytest.param((-1.0, 0.0), (0, 186, 255), id="-u"),
+        pytest.param((0.0, 1.0), (255, 246, 0), id="+v"),
+        pytest.param((0.0, -1.0), (107, 0, 255), id="-v"),
+    ],
+)
+def test_flow2rgb_maps_cardinal_directions_to_colors(
+    uv: tuple[float, float], expected_rgb: tuple[int, int, int]
+) -> None:
+    # The (u, v) direction selects the color-wheel hue; a u/v swap or an
+    # arctan2 sign error would recolor every vector while passing shape and
+    # dtype checks, so pin the four cardinal unit vectors to known colors.
+    flow = np.full((2, 2, 2), uv, dtype=np.float32)
+
+    flow_viz = imgviz.flow2rgb(flow, max_norm=1.0)
+
+    np.testing.assert_array_equal(flow_viz[0, 0], expected_rgb)
+
+
 def test_flow2rgb_rejects_non_3d() -> None:
     flow = np.zeros((4, 4), dtype=np.float32)
     with pytest.raises(ValueError, match="flow must be 3 dimensional"):


### PR DESCRIPTION
`flow2rgb`'s tests only covered shape, dtype, negative-zero handling, and
`max_norm` caching, so the `u`/`v` channel assignment and the `arctan2`
color-wheel mapping had no value coverage. A u/v swap or an `arctan2` sign
error would recolor every flow vector while passing the whole suite.

This pins the four cardinal unit vectors to their known color-wheel colors
(verified against the current output). Swapping the `_flow_compute_color(flow_u,
flow_v)` arguments fails all four cases; the existing suite stays green.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_flow_test.py` (13 passed)
- [x] `uv run --extra all pytest` (480 passed)
- [x] `make lint` equivalents: ruff check, ruff format --check, ty check
