### PR TITLE
test(draw): assert progress_bar fill is linear in value

### DIFF
--- a/tests/unit/draw/_progress_bar_test.py
+++ b/tests/unit/draw/_progress_bar_test.py
@@ -50,6 +50,29 @@ def test_progress_bar_half(white_image: NDArray[np.uint8]) -> None:
     assert tuple(res[20, 80]) == GRAY  # right half is the track
 
 
+@pytest.mark.parametrize(
+    ("value", "green_col", "gray_col"),
+    [(0.25, 29, 31), (0.5, 49, 51), (0.75, 69, 71)],
+)
+def test_progress_bar_fill_boundary_is_linear_in_value(
+    white_image: NDArray[np.uint8], value: float, green_col: int, gray_col: int
+) -> None:
+    # The cases above only pin the endpoints; probing just inside and just
+    # outside the boundary (at 10 + value * 80) catches any non-linear
+    # value->pixel mapping, e.g. an accidental value**2 easing, that would
+    # still leave the endpoints correct.
+    res = imgviz.draw.progress_bar(
+        white_image,
+        yx1=(10, 10),
+        yx2=(30, 90),
+        value=value,
+        fill=GREEN,
+        background=GRAY,
+    )
+    assert tuple(res[20, green_col]) == GREEN
+    assert tuple(res[20, gray_col]) == GRAY
+
+
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
 def test_progress_bar_rejects_non_finite_value(
     white_image: NDArray[np.uint8], value: float


### PR DESCRIPTION
The existing `progress_bar` tests only pin the fill at the endpoints
(`value` 0/1 in `test_progress_bar_fills_region_by_value`) and two far-apart
mid-range points (cols 20/80 in `test_progress_bar_half`), so a non-linear
`value`->pixel mapping that still fixes the endpoints (e.g. an accidental
`value**2` easing) passed the whole suite.

`test_progress_bar_fill_boundary_is_linear_in_value` probes one pixel just
inside and just outside the fill boundary (`10 + value * 80`) for three
mid-range values, locking the linear fill proportionality.

## Test plan
- [x] `uv run --extra all pytest tests/unit/draw/_progress_bar_test.py` (18 passed)
- [x] Mutation-proven teeth: `value * (x2 - x1)` -> `value * value * (x2 - x1)` fails only the 3 new cases; passes on revert
- [x] `make lint` (ruff + format + ty) green
