### PR TITLE
test(heatmap): cover heatmap ±3σ evaluation window

### DIFF
--- a/tests/unit/_heatmap_test.py
+++ b/tests/unit/_heatmap_test.py
@@ -48,6 +48,12 @@ def test_heatmap_sigma_controls_spread() -> None:
     assert wide[50, 70] > narrow[50, 70]  # wider Gaussian reaches further
 
 
+def test_heatmap_window_extends_to_three_sigma() -> None:
+    res = imgviz.heatmap([(50, 50)], shape=(100, 100), sigma=10)
+    # 2.5 sigma away stays inside the +-3 sigma window (drops to 0 if tightened)
+    assert res[50, 75] == pytest.approx(np.exp(-(25**2) / (2 * 10**2)))
+
+
 def test_heatmap_weights() -> None:
     res = imgviz.heatmap(
         [(30, 30), (70, 70)], shape=(100, 100), sigma=8, weights=[1.0, 3.0]


### PR DESCRIPTION
`heatmap` evaluates each Gaussian only over a ±3σ window (`radius = int(np.ceil(3 * sigma))`, `_heatmap.py:59`) for speed, but no test probed the 2σ–3σ band: the existing tests only sample the peak, 1σ, and image-edge clipping, all of which stay inside a tighter window too. So tightening the cutoff (e.g. `3*sigma` → `2*sigma`) would silently zero out real density between 2σ and 3σ and still pass the whole suite.

This adds a single probe at 2.5σ (`res[50, 75]` for a point at `(50, 50)`, `sigma=10`), asserting it equals the closed-form Gaussian `exp(-3.125) ≈ 0.0439`. Under a `2*sigma` window that pixel falls outside the evaluation region and drops to exactly `0.0`, so the test fails. It is a lower-bound guard (still passes if the window is later widened) and backend-invariant (pure numpy, no resize backend).

## Test plan
- [x] `test_heatmap_window_extends_to_three_sigma` fails under `3*sigma → 2*sigma` (0.0 vs 0.0439), passes on revert; only the new test is affected
- [x] full suite green: `uv run --extra all pytest` → 477 passed
- [x] `uv run --extra all ruff check / ruff format --check / ty check`
