### PR TITLE
fix(legend): clamp background wash to image bounds on corner overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `letterbox` returning the input array itself when the image already matches the target size, so mutating the result no longer corrupts the input ([#219](https://github.com/wkentaro/imgviz/pull/219))
 - Fixed `draw.text_in_rectangle` filling the grown canvas with the background's red channel replicated across every channel instead of the full RGB color ([#224](https://github.com/wkentaro/imgviz/pull/224))
 - Fixed `components.legend` truncating instead of rounding its translucent background wash, which biased the blended pixels down by one ([#223](https://github.com/wkentaro/imgviz/pull/223))
+- Fixed `components.legend` silently dropping its translucent background wash when the legend overflows a corner, by clamping the wash region to the image bounds ([#287](https://github.com/wkentaro/imgviz/pull/287))
 
 ## [2.1.0] - 2026-06-10
 

--- a/imgviz/components/_legend.py
+++ b/imgviz/components/_legend.py
@@ -96,6 +96,9 @@ def legend_(
     alpha = 0.5
     y1, x1 = yx1.round().astype(int)
     y2, x2 = yx2.round().astype(int)
+    # Clamp only the start: a negative slice start wraps from the array end
+    # (silently dropping the wash), while an over-large stop is already clipped.
+    y1, x1 = max(y1, 0), max(x1, 0)
     region = np.asarray(image)[y1:y2, x1:x2]
     washed = (alpha * region + alpha * 255).round().astype(np.uint8)
     image.paste(_utils.numpy_to_pillow(washed), (int(x1), int(y1)))

--- a/tests/unit/components/_legend_test.py
+++ b/tests/unit/components/_legend_test.py
@@ -35,6 +35,32 @@ def test_legend_wash_rounds_to_nearest() -> None:
     assert res[5, 5].tolist() == [228, 228, 228]
 
 
+@pytest.mark.parametrize(
+    ("shape", "items", "loc", "probe"),
+    [
+        # A legend taller than the image overflows the top edge for loc="rb", so
+        # its top-left origin lands at a negative row.
+        ((100, 200, 3), [("a", (0, 255, 0))] * 5, "rb", (50, 149)),
+        # A legend wider than the image overflows the left edge for loc="rt", so
+        # its top-left origin lands at a negative column.
+        ((200, 100, 3), [("wide legend label", (0, 255, 0))], "rt", (20, 0)),
+    ],
+)
+def test_legend_wash_renders_when_legend_overflows_corner(
+    shape: tuple[int, int, int],
+    items: list[tuple[str, tuple[int, int, int]]],
+    loc: Literal["lt", "rt", "lb", "rb"],
+    probe: tuple[int, int],
+) -> None:
+    # The background wash must still render over the on-canvas region instead of
+    # silently vanishing when the legend spills off its anchor corner.
+    image = np.full(shape, 100, dtype=np.uint8)
+    res = imgviz.components.legend(image, items=items, font_size=25, loc=loc)
+    # 0.5 * 100 + 0.5 * 255 = 177.5, rounded to 178, probed at a wash pixel
+    # outside the color swatches.
+    assert res[probe].tolist() == [178, 178, 178]
+
+
 def test_legend_empty_items_is_noop(white_image: NDArray[np.uint8]) -> None:
     res = imgviz.components.legend(white_image, items=[])
     assert np.array_equal(res, white_image)


### PR DESCRIPTION
`components.legend` computes its translucent background-wash region from the
legend's own size, so when the legend is taller or wider than the image allows
from its anchor corner, the top-left origin lands at a negative row/column.
Those raw negative indices went straight into a NumPy slice
(`np.asarray(image)[y1:y2, x1:x2]`), where a negative start counts from the
opposite edge rather than clipping to 0, so the wash region came out empty or
mis-sourced and the semi-transparent panel silently failed to render, even
though the color swatches and text (clipped by Pillow's `paste`) still drew.
Clamping the slice start to the image bounds fixes it; the stop index is left to
NumPy's own slice clipping, and a fitting legend is bit-identical to before.

## Test plan
- [x] Added `test_legend_wash_renders_when_legend_overflows_corner`, parametrized
      over top-overflow (`loc="rb"`) and side-overflow (`loc="rt"`) to cover both
      the row and column clamp; each case fails on the pre-fix code and passes
      after (mutation-verified per axis)
- [x] `uv run --extra all pytest -n=auto tests` — 478 passed
- [x] `ruff format --check` / `ruff check` / `ty check` clean
- [x] Behavioral: a fitting legend is bit-identical to `main` across all four
      `loc` values (md5-matched); the overflow case now renders the wash panel
