### PR TITLE
refactor: extract shared require_uint8_image validation helper

### DIFF
--- a/imgviz/_color.py
+++ b/imgviz/_color.py
@@ -125,6 +125,26 @@ def rgba2rgb(rgba: NDArray[np.uint8]) -> NDArray[np.uint8]:
     return rgb
 
 
+def require_uint8_image(image: NDArray) -> NDArray[np.uint8]:
+    """Validate a uint8 image and promote 2D grayscale to RGB.
+
+    Args:
+        image: Input image with shape (H, W) or (H, W, C).
+
+    Returns:
+        The image with a channel axis, grayscale promoted via gray2rgb.
+    """
+    if not isinstance(image, np.ndarray):
+        raise TypeError(f"image must be a numpy array, but got {type(image).__name__}")
+    if image.dtype != np.uint8:
+        raise ValueError(f"image dtype must be np.uint8, but got {image.dtype}")
+    if image.ndim == 2:
+        image = gray2rgb(image)
+    if image.ndim != 3:
+        raise ValueError(f"image must be 2 or 3 dimensional, but got {image.ndim}")
+    return image
+
+
 def asgray(image: NDArray) -> NDArray[np.uint8]:
     """Convert any array to gray image.
 

--- a/imgviz/_flags.py
+++ b/imgviz/_flags.py
@@ -58,14 +58,7 @@ def flags2rgb(
     """
     OFF_COLOR: Final = (200, 200, 200)
 
-    if not isinstance(image, np.ndarray):
-        raise TypeError(f"image must be a numpy array, but got {type(image).__name__}")
-    if image.dtype != np.uint8:
-        raise ValueError(f"image dtype must be np.uint8, but got {image.dtype}")
-    if image.ndim == 2:
-        image = _color.gray2rgb(image)
-    if image.ndim != 3:
-        raise ValueError(f"image must be 2 or 3 dimensional, but got {image.ndim}")
+    image = _color.require_uint8_image(image)
 
     if not isinstance(flags, np.ndarray):
         raise TypeError(f"flags must be a numpy array, but got {type(flags).__name__}")

--- a/imgviz/_instances.py
+++ b/imgviz/_instances.py
@@ -66,15 +66,7 @@ def instances2rgb(
     Returns:
         Visualized image with shape (H, W, 3).
     """
-    if not isinstance(image, np.ndarray):
-        raise TypeError(f"image must be a numpy array, but got {type(image).__name__}")
-    if image.dtype != np.uint8:
-        raise ValueError(f"image dtype must be np.uint8, but got {image.dtype}")
-
-    if image.ndim == 2:
-        image = _color.gray2rgb(image)
-    if image.ndim != 3:
-        raise ValueError(f"image must be 2 or 3 dimensional, but got {image.ndim}")
+    image = _color.require_uint8_image(image)
 
     negative_labels = [label_i for label_i in labels if label_i < 0]
     if negative_labels:


### PR DESCRIPTION
## Summary
- Extract `_color.require_uint8_image`, folding the image-validation block that `instances2rgb` and `flags2rgb` each carried inline verbatim: numpy-array check (`TypeError`), uint8-dtype check (`ValueError`), 2D-grayscale promotion via `gray2rgb`, and a 2-or-3-dimensional check (`ValueError`).
- Byte-identical: same check order, exception types, and message text; the grayscale promotion still routes through `_color.gray2rgb`. Both call sites collapse to `image = _color.require_uint8_image(image)`.

## Test plan
- [x] `uv run --extra all pytest` (476 passed) — existing guard tests lock every branch on both sides (`test_instances2rgb_rejects_non_array`/`_rejects_non_uint8`/`_accepts_grayscale_image`/`_rejects_4d_image`, `test_flags2rgb_validates_inputs`)
- [x] `make lint` equivalent: `ruff check`, `ruff format --check`, `ty check` all green
