### PR TITLE
test(data): pin kitti_odometry pose parsing output values

### DIFF
--- a/tests/unit/data/kitti_test.py
+++ b/tests/unit/data/kitti_test.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+import imgviz
+
+
+def test_kitti_odometry_parses_pose_values() -> None:
+    data = imgviz.data.kitti_odometry()
+    assert isinstance(data, dict)
+
+    transforms = data["transforms"]
+    assert len(transforms) == 4541
+    assert transforms[0].shape == (4, 4)
+    assert transforms[0].dtype == np.float64
+
+    # Each line's 12 floats fill the top three rows row-major, and the bottom
+    # row is the appended homogeneous [0, 0, 0, 1]; the translation column is
+    # the 4th value of each triplet.
+    np.testing.assert_array_equal(transforms[1][3], [0, 0, 0, 1])
+    np.testing.assert_array_equal(
+        transforms[1][:3, 3], [-4.690294e-02, -2.839928e-02, 8.586941e-01]
+    )


### PR DESCRIPTION
`imgviz.data.kitti_odometry()` (and its helper `read_pose_file`) had no test
coverage at all: the loader was never invoked from the suite, so the pose-matrix
parse (each line's 12 floats reshaped row-major into a 4x4 with an appended
homogeneous row) had zero pins on its output. A wrong reshape order or a
corrupted homogeneous row passed every existing test.

This follows the one-test-per-data-loader pattern (#244 lena, #248 middlebury).
The pinned values are verified byte-exact against the bundled
`imgviz/data/kitti/odometry/00.txt`.

## Test plan
- [x] `uv run --extra all pytest tests/unit/data/kitti_test.py` (1 passed)
- [x] mutation-checked: appending `[0, 0, 1, 0]` instead of `[0, 0, 0, 1]`, and
      reshaping in `order="F"`, each fail the new test; both pass on revert
- [x] full suite `uv run --extra all pytest tests/` (477 passed) + `make lint`
