### PR TITLE
test(data): cover compose_class_label and read_class_names

### DIFF
--- a/tests/unit/data/data_utils_test.py
+++ b/tests/unit/data/data_utils_test.py
@@ -1,0 +1,30 @@
+import pathlib
+
+import numpy as np
+
+from imgviz.data import _utils
+
+
+def test_compose_class_label_paints_last_mask_over_overlap() -> None:
+    masks = np.array(
+        [
+            [[1, 1, 0], [2, 0, 0]],
+            [[0, 1, 1], [0, 0, 0]],
+        ],
+        dtype=np.int32,
+    )
+    labels = np.array([7, 3], dtype=np.int32)
+
+    class_label = _utils.compose_class_label(shape=(2, 3), labels=labels, masks=masks)
+
+    np.testing.assert_array_equal(class_label, [[7, 3, 3], [0, 0, 0]])
+    assert class_label.dtype == np.int32
+
+
+def test_read_class_names_strips_whitespace(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "class_names.txt"
+    path.write_text("  cat \ndog\n")
+
+    class_names = _utils.read_class_names(path)
+
+    assert class_names == ["cat", "dog"]


### PR DESCRIPTION
`imgviz/data/_utils.py` — the shared helper module behind the `arc2017` and `voc`
data loaders — had no direct test coverage. Its two functions were only exercised
indirectly, so `compose_class_label`'s mask-to-label composition and
`read_class_names`'s parsing had no value pins.

`compose_class_label` is asserted with an int32 `{0, 1, 2}` mask fixture that
mirrors arc2017's real `data.npz` domain (masks are passed in raw, un-binarized).
It pins three behaviors: background stays `0`, overlapping masks resolve
last-mask-wins, and the strict `mask == 1` selection excludes the `2` ignore value
(so a `mask == 1` → `mask > 0` or a max-vectorization regression is caught).
`read_class_names` pins per-line whitespace stripping.

The file is named `data_utils_test.py` (not `_utils_test.py`) to avoid a pytest
module-name collision with the existing `tests/unit/_utils_test.py` under the
repo's no-`__init__.py` test layout, mirroring the sibling `arc2017_test.py`
package-name convention.

## Test plan
- [x] `uv run --extra all pytest` (478 passed)
- [x] mutation-proven teeth (clear `__pycache__` + `--reinstall-package`): each of
      background=0, overlap order, `== 1` exclusion, and `.strip()` fails only the
      relevant new assertion and passes on revert
- [x] `make lint` (ruff + format + ty) green on the new file
