### PR TITLE
refactor(draw): use require_pil_image helper in box_corners_

### DIFF
--- a/imgviz/draw/_box_corners.py
+++ b/imgviz/draw/_box_corners.py
@@ -6,6 +6,7 @@ from numpy.typing import NDArray
 from .. import _utils
 from ._ink import Ink
 from ._ink import get_pil_ink
+from ._ink import require_pil_image
 
 
 def box_corners(
@@ -61,10 +62,7 @@ def box_corners_(
             width/height, so a large value degrades to a full rectangle.
         width: Line width.
     """
-    if not isinstance(image, PIL.Image.Image):
-        raise TypeError(
-            f"image must be PIL.Image.Image, but got {type(image).__name__}"
-        )
+    require_pil_image(image=image)
     y1, x1 = map(float, yx1)
     y2, x2 = map(float, yx2)
     if y2 < y1 or x2 < x1:


### PR DESCRIPTION
`box_corners_` carried a verbatim inline copy of the PIL-image type guard already
extracted as `require_pil_image` in `_ink.py` and consumed by `line_` and
`polygon_` (with `arrow_` folding in via #272). This routes `box_corners_` through
the shared helper too, making it the last in-place draw primitive to drop its
inline copy.

Byte-identical: same `TypeError`, same message text, same trigger, same position
(first check, before the `yx1`/`yx2` shape validation). The existing
`test_box_corners_rejects_non_pil_image` (`match="PIL.Image.Image"`) locks the
behavior unchanged.

Distinct from #208, which *adds* the guard to primitives that never had it (a
behavior change: `AttributeError` -> `TypeError`); `box_corners_` already
validated, so this is a pure dedup, not in #208's scope.

## Test plan
- [x] `uv run --extra all pytest` (476 passed)
- [x] `make lint` equivalent: `ruff check`, `ruff format --check`, `ty check` all clean
