### PR TITLE
test(draw): cover circle center axis order and disc radius

### DIFF
--- a/tests/unit/draw/_circle_test.py
+++ b/tests/unit/draw/_circle_test.py
@@ -12,6 +12,25 @@ def test_circle() -> None:
     assert not np.array_equal(res, img)
 
 
+def test_circle_center_is_yx_not_xy() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    center = (30, 70)
+    res = imgviz.draw.circle(img, center=center, diameter=20, fill=(0, 0, 255))
+    cy, cx = center
+    assert (res[cy, cx] == (0, 0, 255)).all()
+    assert (res[cx, cy] == (255, 255, 255)).all()
+
+
+def test_circle_fills_disc_of_diameter() -> None:
+    img = np.full((100, 100, 3), 255, dtype=np.uint8)
+    res = imgviz.draw.circle(img, center=(30, 70), diameter=20, fill=(0, 0, 255))
+    assert (res[30, 78] == (0, 0, 255)).all()
+    assert (res[30, 82] == (255, 255, 255)).all()
+    assert (res[38, 70] == (0, 0, 255)).all()
+    assert (res[42, 70] == (255, 255, 255)).all()
+    assert (res[22, 62] == (255, 255, 255)).all()
+
+
 def test_circle_rejects_missing_fill_and_outline() -> None:
     img = np.full((100, 100, 3), 255, dtype=np.uint8)
     with pytest.raises(ValueError, match="at least one of `fill` or `outline`"):


### PR DESCRIPTION
`draw.circle` had only `test_circle`, which asserts shape/dtype/"something changed" — the `center=(cy, cx)` axis order and the `diameter`-to-radius fill boundary were both unverified. `circle_` still computes its own bbox (`cy, cx = center; radius = diameter / 2.0`), so a `(cy, cx)` swap or a dropped `/2.0` shipped undetected. This completes the axis-swap/geometry coverage already added for the sibling draw primitives (star/triangle/pie/line/rectangle/rounded_rectangle/rotated_rectangle/ellipse).

- `test_circle_center_is_yx_not_xy` — asymmetric `center=(30, 70)`; a `(cy, cx)` unpack swap flips both probes.
- `test_circle_fills_disc_of_diameter` — cardinal probes pin the radius-10 boundary on both axes; a diagonal probe (inside the bbox square, outside the disc) pins roundness so an `ellipse`→`rectangle` bbox fill is caught.

## Test plan
- [x] Each assertion mutation-verified: `(cy,cx)` swap and `radius=diameter` fail both tests; `ellipse`→`rectangle` fails only the diagonal probe (`__pycache__` cleared + `--reinstall-package`)
- [x] `uv run --extra all pytest -q` — 478 passed
- [x] `ruff check` / `ruff format --check` / `ty check` clean
