### PR TITLE
test(draw): cover polygon vertex yx axis order

### DIFF
--- a/tests/unit/draw/_polygon_test.py
+++ b/tests/unit/draw/_polygon_test.py
@@ -28,6 +28,14 @@ def test_polygon_fill_only(white_image: NDArray[np.uint8]) -> None:
     assert (res[50, 50] == (255, 0, 0)).all()
 
 
+def test_polygon_vertices_are_yx_not_xy(white_image: NDArray[np.uint8]) -> None:
+    res = imgviz.draw.polygon(
+        white_image, yx=[(20, 10), (20, 90), (30, 50)], fill=(255, 0, 0)
+    )
+    assert (res[25, 50] == (255, 0, 0)).all()
+    assert (res[50, 25] == (255, 255, 255)).all()
+
+
 def test_polygon_fill_and_outline_with_width(
     white_image: NDArray[np.uint8],
 ) -> None:


### PR DESCRIPTION
`draw.polygon` reverses `(y, x)` vertices to Pillow's `(x, y)` at `xy = yx[:, ::-1]`
(`imgviz/draw/_polygon.py:66`), but its prior tests only used transpose-symmetric
squares and a near-symmetric down-triangle, so a dropped/misapplied reversal was
invisible — all 10 existing polygon tests pass with the swap removed. This was the
base draw primitive missed by the earlier axis-swap sweep (line/rectangle/ellipse/
pie/rotated_rectangle/circle/…).

The new test draws an extreme-aspect triangle `yx=[(20,10),(20,90),(30,50)]` and
probes two transposed pixels — `res[25,50]` (inside the true triangle, red) and
`res[50,25]` (inside only the swapped triangle, white) — each of which flips
independently when the axis reversal is dropped.

## Test plan
- [x] `uv run --extra all pytest` (477 passed)
- [x] mutation-proven: `xy = yx[:, ::-1]` → `xy = yx` fails both probes; reverting restores 11/11
- [x] `make lint` (ruff + format + ty green)
