### PR TITLE
test(colorize): pin viridis output values to catch dropped rounding

### DIFF
--- a/tests/unit/_colorize_test.py
+++ b/tests/unit/_colorize_test.py
@@ -97,3 +97,20 @@ def test_colorize_nan_renders_as_black() -> None:
     out = imgviz.colorize(scalar, vmin=0.0, vmax=1.0)
 
     np.testing.assert_array_equal(out[0, 1], [0, 0, 0])
+
+
+def test_colorize_maps_normalized_values_to_viridis_colors() -> None:
+    scalar = np.array([[0.0, 0.25, 0.5, 0.75, 1.0]], dtype=np.float32)
+
+    out = imgviz.colorize(scalar, vmin=0.0, vmax=1.0, cmap="viridis")
+
+    np.testing.assert_array_equal(
+        out[0],
+        [
+            [68, 1, 84],
+            [59, 82, 139],
+            [33, 145, 140],
+            [94, 201, 98],
+            [253, 231, 37],
+        ],
+    )


### PR DESCRIPTION
`colorize()` had no test asserting a concrete output pixel value — every
existing test in the file checks only shape, dtype, cross-call equality, or the
NaN-to-black pixel. Dropping the `.round()` before the uint8 cast (truncation
instead of round-to-nearest, `_colorize.py:104`) passed the whole file.

This pins `colorize()` of a scalar row through viridis to its canonical anchor
swatches (`#440154`/`#3b528b`/`#21918c`/`#5ec962`/`#fde725`, matplotlib's
documented 5-stop viridis reference), covering normalization, colormap
application, the `*255` scale, and the round-to-nearest cast. The interior
anchors land off-integer, so a dropped `.round()` flips them.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_colorize_test.py` (12 passed)
- [x] mutation-verified: dropping `.round()` in `_colorize.py` fails only this test; passes on revert
- [x] `make lint` (ruff + format + ty) green
