### PR TITLE
test(color): pin get_fg_color threshold and rgba2rgb channel values

### DIFF
--- a/tests/unit/_color_test.py
+++ b/tests/unit/_color_test.py
@@ -64,6 +64,12 @@ def test_asrgba(images: dict[str, NDArray[np.uint8]]) -> None:
         assert result.shape[2] == 4
 
 
+def test_rgba2rgb_returns_rgb_channels(
+    images: dict[str, NDArray[np.uint8]],
+) -> None:
+    np.testing.assert_array_equal(imgviz.rgba2rgb(images["rgba"]), images["rgb"])
+
+
 def test_rgb2hsv() -> None:
     rgb = np.zeros((10, 10, 3), dtype=np.uint8)
     rgb[:, :, 0] = 255  # red
@@ -87,6 +93,14 @@ def test_get_fg_color() -> None:
     assert get_fg_color((0, 0, 0)) == (255, 255, 255)
     # Light background -> black foreground
     assert get_fg_color((255, 255, 255)) == (0, 0, 0)
+
+
+def test_get_fg_color_switches_at_intensity_boundary() -> None:
+    from imgviz._color import get_fg_color
+
+    # intensity 170 stays below the threshold; 171 crosses it
+    assert get_fg_color((170, 170, 170)) == (255, 255, 255)
+    assert get_fg_color((171, 171, 171)) == (0, 0, 0)
 
 
 @pytest.mark.parametrize("convert", [imgviz.rgb2gray, imgviz.rgb2rgba, imgviz.rgb2hsv])


### PR DESCRIPTION
## Summary
- `get_fg_color` was only pinned at the two intensity extremes (`(0,0,0)` -> white, `(255,255,255)` -> black), leaving the `> 170` threshold and its direction unverified. Add `test_get_fg_color_switches_at_intensity_boundary` pinning `(170,170,170)` -> white and `(171,171,171)` -> black, which locks the exact 170 cut point and the `>` direction (`rgb2gray` maps a solid gray `v` to `v`).
- `rgba2rgb`'s `rgba[:, :, :3]` slice was never value-checked: the `asrgb` tests assert only aliasing/copy semantics, self-referentially against the same slice. Add `test_rgba2rgb_returns_rgb_channels`, an `rgb2rgba` -> `rgba2rgb` round-trip against the real arc2017 image reusing the existing `images` fixture.

Both were documented output-value gaps that shape/dtype/aliasing tests miss.

## Test plan
- [x] both mutation-verified (clean `__pycache__` + `--reinstall-package` rebuild): `> 170` -> `>= 170` fails only the boundary test; `rgba[:, :, :3]` -> `rgba[:, :, 1:]` fails only the round-trip test; each reverts to 478 green
- [x] `uv run --extra all pytest tests/` (478 passed)
- [x] `make lint` (ruff + format + ty green)
