### PR TITLE
test: pin resize rounding of fractional dimensions to nearest

### DIFF
--- a/tests/unit/_resize_test.py
+++ b/tests/unit/_resize_test.py
@@ -30,6 +30,24 @@ def test_resize(rgb: NDArray[np.uint8]) -> None:
     assert dst.dtype == np.uint8
 
 
+@pytest.mark.parametrize(
+    "height, width, expected_shape",
+    [
+        pytest.param(0.85, 0.75, (13, 19, 3), id="float-scale-both-axes"),
+        pytest.param(None, 11, (7, 11, 3), id="width-only-derives-height"),
+        pytest.param(13, None, (13, 22, 3), id="height-only-derives-width"),
+    ],
+)
+def test_resize_rounds_fractional_dimension_to_nearest(
+    rgb: NDArray[np.uint8],
+    height: int | float | None,
+    width: int | float | None,
+    expected_shape: tuple[int, ...],
+) -> None:
+    dst = imgviz.resize(rgb, height=height, width=width)
+    assert dst.shape == expected_shape
+
+
 def test_resize_backends_agree_on_shape(rgb: NDArray[np.uint8]) -> None:
     via_pillow = imgviz.resize(rgb, height=12, backend="pillow")
     via_opencv = imgviz.resize(rgb, height=12, backend="opencv")


### PR DESCRIPTION
`imgviz.resize` computes each output dimension with `int(round(scale * dim))`,
but no existing test exercised that rounding with a fractional product: the `rgb`
fixture is `(15, 25)` and every prior case resizes it by exact-integer ratios
(0.8 → 12.0 / 20.0), so a `round`→truncate regression would ship an off-by-one
resize dimension and still pass the whole suite.

This adds three parametrized cases whose scale × dimension lands off-integer,
covering both the explicit float-scale path and the aspect-ratio-derived path:

- `float-scale-both-axes` — `height=0.85, width=0.75` → `(13, 19)` (12.75→13, 18.75→19)
- `width-only-derives-height` — `width=11` → `(7, 11)` (6.6→7)
- `height-only-derives-width` — `height=13` → `(13, 22)` (21.67→22)

Under a `round`→`int` truncation the shapes collapse to `(12, 18)` / `(6, 11)` /
`(13, 21)`, so each case fails. The dimension math runs before backend dispatch,
so the check is backend-invariant.

## Test plan
- [x] `uv run --extra all pytest tests/unit/_resize_test.py` (20 passed)
- [x] mutation check: `int(round(...))` → `int(...)` fails all 3 new cases, others pass
- [x] `ruff check` / `ruff format --check` / `ty check` green
