### PR TITLE
test(normalize): cover constant-zero issame spread floor

### DIFF
--- a/tests/unit/_normalize_test.py
+++ b/tests/unit/_normalize_test.py
@@ -33,6 +33,18 @@ def test_normalize_constant_large_float32_is_finite() -> None:
     assert np.isfinite(result).all()
 
 
+def test_normalize_constant_zero_maps_to_midpoint() -> None:
+    # When min == max == 0, the issame spread is eps * abs(value) == 0 without
+    # the maximum(..., 1.0) floor, so the range stays collapsed and 0 / 0 gives
+    # NaN. The floor keeps the spread finite, mapping the constant to 0.5.
+    src = np.zeros((4, 4), dtype=np.float32)
+
+    result = imgviz.normalize(src)
+
+    assert result.shape == src.shape
+    np.testing.assert_allclose(result, 0.5)
+
+
 def test_normalize_multichannel_maps_each_channel_to_0_1() -> None:
     src = np.array(
         [


### PR DESCRIPTION
`normalize()` widens a collapsed range (`min_value == max_value`) with a
magnitude-proportional spread: `eps * np.maximum(np.abs(min_value), 1.0)`. The
`np.maximum(..., 1.0)` floor exists for the near-zero case — without it, a
constant-zero image gives `spread = eps * 0 == 0`, the range stays collapsed,
and the division yields `0 / 0 == NaN`. The only existing test covering this
branch (`test_normalize_constant_large_float32_is_finite`) uses `1e6`, where the
floor is a no-op, so dropping the `1.0` floor passes the whole suite.

This adds `test_normalize_constant_zero_maps_to_midpoint`, pinning that a
constant-zero image maps to the finite midpoint `0.5`. Forward-compatible with
open PR #257, which only touches the dense-compute region below this block.

## Test plan
- [x] `test_normalize_constant_zero_maps_to_midpoint` added; mutation-proven — dropping the `np.maximum(..., 1.0)` floor fails only the new test (11/12 pass), reverting restores 12/12
- [x] `uv run --extra all pytest tests/` (477 passed)
- [x] `ruff check` / `ruff format --check` / `ty check` green
