### PR TITLE
test(arc2017): pin field wiring of arc2017() data dict

### DIFF
--- a/tests/unit/data/arc2017_test.py
+++ b/tests/unit/data/arc2017_test.py
@@ -1,6 +1,42 @@
+import numpy as np
+
 import imgviz
 
 
 def test_arc2017() -> None:
     data = imgviz.data.arc2017()
     assert isinstance(data, dict)
+
+
+def test_arc2017_wires_expected_fields() -> None:
+    data = imgviz.data.arc2017()
+
+    height, width = 480, 640
+    num_instances = 8
+
+    assert data["rgb"].dtype == np.uint8
+    assert data["rgb"].shape == (height, width, 3)
+
+    assert data["depth"].dtype == np.float32
+    assert data["depth"].shape == (height, width)
+
+    assert data["bboxes"].dtype == np.float32
+    assert data["bboxes"].shape == (num_instances, 4)
+
+    assert data["labels"].dtype == np.int32
+    assert data["labels"].shape == (num_instances,)
+
+    assert data["masks"].dtype == np.int32
+    assert data["masks"].shape == (num_instances, height, width)
+
+    assert data["class_label"].dtype == np.int32
+    assert data["class_label"].shape == (height, width)
+
+    assert isinstance(data["class_names"], list)
+    assert len(data["class_names"]) == 41
+    assert all(isinstance(name, str) for name in data["class_names"])
+
+    assert data["res4"].dtype == np.float32
+    assert data["res4"].shape == (30, 40, 1024)
+
+    assert isinstance(data["camera_info"], dict)


### PR DESCRIPTION
The only prior test for `imgviz.data.arc2017()` asserted `isinstance(data, dict)`, leaving the whole structural assembly of the returned `_Arc2017Data` unverified. A realistic wiring slip in the return statement (e.g. `depth` sourced from `rgb`) passed the smoke test.

This adds `test_arc2017_wires_expected_fields`, pinning each field against the bundled fixture's fixed values as an independent oracle: dtypes, exact shapes (`rgb`/`depth`/`bboxes`/`labels`/`masks`/`class_label`/`res4`), the `rgb`/`depth`/`masks`/`class_label` height/width and per-instance count relationships, `class_names` as a 41-element `list[str]`, and `camera_info` as a `dict`.

## Test plan
- [x] `uv run --extra all pytest tests/unit` — 477 passed
- [x] teeth: mutating the return to wire `depth` from `rgb` fails the new test while the smoke test still passes
- [x] `make lint` (ruff + format + ty) green
