### PR TITLE
fix(draw): raise TypeError from every in-place primitive on non-PIL input

### DIFF
--- a/changelog.d/310.fixed.md
+++ b/changelog.d/310.fixed.md
@@ -1,0 +1,1 @@
+Fixed in-place `draw` primitives failing inside Pillow instead of raising `TypeError` when given a non-PIL image

--- a/imgviz/draw/_arrow.py
+++ b/imgviz/draw/_arrow.py
@@ -1,11 +1,11 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 
 
@@ -65,10 +65,7 @@ def arrow_(
         head_length_ratio: Arrowhead length as a fraction of the shaft length.
         head_angle: Half-angle of the arrowhead in degrees.
     """
-    if not isinstance(image, PIL.Image.Image):
-        raise TypeError(
-            f"image must be PIL.Image.Image, but got {type(image).__name__}"
-        )
+    draw = get_draw(image)
     tail = np.asarray(yx1, dtype=float)
     tip = np.asarray(yx2, dtype=float)
     if tail.shape != (2,):
@@ -76,7 +73,6 @@ def arrow_(
     if tip.shape != (2,):
         raise ValueError(f"yx2 must have shape (2,), but got {tip.shape}")
 
-    draw = PIL.ImageDraw.Draw(image)
     pil_fill = get_pil_ink(fill)
 
     y1, x1 = float(tail[0]), float(tail[1])

--- a/imgviz/draw/_box_corners.py
+++ b/imgviz/draw/_box_corners.py
@@ -1,10 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 
 
@@ -61,10 +61,7 @@ def box_corners_(
             width/height, so a large value degrades to a full rectangle.
         width: Line width.
     """
-    if not isinstance(image, PIL.Image.Image):
-        raise TypeError(
-            f"image must be PIL.Image.Image, but got {type(image).__name__}"
-        )
+    draw = get_draw(image)
     y1, x1 = map(float, yx1)
     y2, x2 = map(float, yx2)
     if y2 < y1 or x2 < x1:
@@ -72,7 +69,6 @@ def box_corners_(
             f"yx1 must be the min vertex and yx2 the max, but got {yx1=}, {yx2=}"
         )
 
-    draw = PIL.ImageDraw.Draw(image)
     pil_fill = get_pil_ink(fill)
 
     tick_x = float(min(length, x2 - x1))

--- a/imgviz/draw/_circle.py
+++ b/imgviz/draw/_circle.py
@@ -1,10 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
 
@@ -62,7 +62,7 @@ def circle_(
     """
     require_fill_or_outline(fill, outline)
 
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     cy, cx = center
 

--- a/imgviz/draw/_ellipse.py
+++ b/imgviz/draw/_ellipse.py
@@ -1,10 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
 
@@ -55,7 +55,7 @@ def ellipse_(
     """
     require_fill_or_outline(fill, outline)
 
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     y1, x1 = yx1
     y2, x2 = yx2

--- a/imgviz/draw/_ink.py
+++ b/imgviz/draw/_ink.py
@@ -3,6 +3,7 @@ from typing import TypeAlias
 
 import numpy as np
 import PIL.Image
+import PIL.ImageDraw
 from numpy.typing import NDArray
 
 Ink: TypeAlias = (
@@ -30,8 +31,10 @@ def require_fill_or_outline(fill: Ink | None, outline: Ink | None) -> None:
         raise ValueError("at least one of `fill` or `outline` must be set")
 
 
-def require_pil_image(*, image: PIL.Image.Image) -> None:
+def get_draw(image: PIL.Image.Image) -> PIL.ImageDraw.ImageDraw:
+    """Return the drawing context for a PIL image, rejecting anything else."""
     if not isinstance(image, PIL.Image.Image):
         raise TypeError(
             f"image must be PIL.Image.Image, but got {type(image).__name__}"
         )
+    return PIL.ImageDraw.Draw(image)

--- a/imgviz/draw/_line.py
+++ b/imgviz/draw/_line.py
@@ -1,13 +1,12 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
-from ._ink import require_pil_image
 
 
 def line(
@@ -46,14 +45,12 @@ def line_(
         fill: RGB color to draw the line.
         width: Line width.
     """
-    require_pil_image(image=image)
+    draw = get_draw(image)
     yx = np.asarray(yx)
     if yx.ndim != 2:
         raise ValueError(f"yx must be 2D array, but got {yx.ndim}D")
     if yx.shape[1] != 2:
         raise ValueError(f"yx.shape[1] must be 2, but got {yx.shape[1]}")
-
-    draw = PIL.ImageDraw.Draw(image)
 
     xy = yx[:, ::-1]
     xy = xy.flatten().tolist()

--- a/imgviz/draw/_pie.py
+++ b/imgviz/draw/_pie.py
@@ -2,11 +2,11 @@ from collections.abc import Sequence
 
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 
 
@@ -71,7 +71,7 @@ def pie_(
     if n == 0:
         return
 
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     cy, cx = center
     radius = diameter / 2.0

--- a/imgviz/draw/_polygon.py
+++ b/imgviz/draw/_polygon.py
@@ -1,14 +1,13 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
-from ._ink import require_pil_image
 
 
 def polygon(
@@ -53,7 +52,7 @@ def polygon_(
         outline: RGB color to draw the outline. None for no outline.
         width: Outline width.
     """
-    require_pil_image(image=image)
+    draw = get_draw(image)
     require_fill_or_outline(fill, outline)
     yx = np.asarray(yx)
     if yx.ndim != 2:
@@ -64,7 +63,6 @@ def polygon_(
         raise ValueError(f"yx must have at least 3 vertices, but got {yx.shape[0]}")
 
     xy = yx[:, ::-1].flatten().tolist()
-    draw = PIL.ImageDraw.Draw(image)
     draw.polygon(
         xy=xy,
         fill=get_pil_ink(fill),

--- a/imgviz/draw/_rectangle.py
+++ b/imgviz/draw/_rectangle.py
@@ -1,10 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
 
@@ -62,7 +62,7 @@ def rectangle_(
     """
     require_fill_or_outline(fill, outline)
 
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     y1, x1 = map(float, yx1)
     y2, x2 = map(float, yx2)

--- a/imgviz/draw/_rounded_rectangle.py
+++ b/imgviz/draw/_rounded_rectangle.py
@@ -1,10 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
 
@@ -67,7 +67,7 @@ def rounded_rectangle_(
     """
     require_fill_or_outline(fill, outline)
 
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     y1, x1 = map(float, yx1)
     y2, x2 = map(float, yx2)

--- a/imgviz/draw/_star.py
+++ b/imgviz/draw/_star.py
@@ -1,10 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
 
@@ -62,7 +62,7 @@ def star_(
     """
     require_fill_or_outline(fill, outline)
 
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     radius = size / 2
     cy, cx = center

--- a/imgviz/draw/_text.py
+++ b/imgviz/draw/_text.py
@@ -2,12 +2,12 @@ import pathlib
 
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 import PIL.ImageFont
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 
 _here: pathlib.Path = pathlib.Path(__file__).parent
@@ -97,7 +97,7 @@ def text_(
         color: Text RGB color in uint8. Default is (0, 0, 0), which is black.
         font_path: Font path. Default font is DejaVuSansMono.
     """
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     y1, x1 = yx
     font = _get_font(size=size, font_path=font_path)

--- a/imgviz/draw/_triangle.py
+++ b/imgviz/draw/_triangle.py
@@ -1,10 +1,10 @@
 import numpy as np
 import PIL.Image
-import PIL.ImageDraw
 from numpy.typing import NDArray
 
 from .. import _utils
 from ._ink import Ink
+from ._ink import get_draw
 from ._ink import get_pil_ink
 from ._ink import require_fill_or_outline
 
@@ -62,7 +62,7 @@ def triangle_(
     """
     require_fill_or_outline(fill, outline)
 
-    draw = PIL.ImageDraw.Draw(image)
+    draw = get_draw(image)
 
     radius = size / 2
     cy, cx = center

--- a/tests/unit/draw/_ink_test.py
+++ b/tests/unit/draw/_ink_test.py
@@ -1,7 +1,10 @@
+from collections.abc import Callable
+
 import numpy as np
 import pytest
 from numpy.typing import NDArray
 
+import imgviz
 from imgviz.draw._ink import Ink
 from imgviz.draw._ink import get_pil_ink
 from imgviz.draw._ink import require_fill_or_outline
@@ -47,3 +50,54 @@ def test_require_fill_or_outline_accepts_when_set(
     fill: Ink | None, outline: Ink | None
 ) -> None:
     require_fill_or_outline(fill, outline)
+
+
+@pytest.mark.parametrize(
+    "draw_",
+    [
+        lambda img: imgviz.draw.arrow_(img, yx1=(0, 0), yx2=(5, 5), fill=(255, 0, 0)),
+        lambda img: imgviz.draw.box_corners_(
+            img, yx1=(0, 0), yx2=(5, 5), fill=(255, 0, 0)
+        ),
+        lambda img: imgviz.draw.circle_(
+            img, center=(5, 5), diameter=4, fill=(255, 0, 0)
+        ),
+        lambda img: imgviz.draw.ellipse_(img, yx1=(0, 0), yx2=(5, 5), fill=(255, 0, 0)),
+        lambda img: imgviz.draw.line_(img, yx=[(0, 0), (5, 5)], fill=(255, 0, 0)),
+        lambda img: imgviz.draw.pie_(
+            img, center=(5, 5), diameter=4, fills=[(255, 0, 0)]
+        ),
+        lambda img: imgviz.draw.polygon_(
+            img, yx=[(0, 0), (5, 5), (0, 5)], fill=(255, 0, 0)
+        ),
+        lambda img: imgviz.draw.rectangle_(
+            img, yx1=(0, 0), yx2=(5, 5), fill=(255, 0, 0)
+        ),
+        lambda img: imgviz.draw.rounded_rectangle_(
+            img, yx1=(0, 0), yx2=(5, 5), radius=1, fill=(255, 0, 0)
+        ),
+        lambda img: imgviz.draw.star_(img, center=(5, 5), size=4, fill=(255, 0, 0)),
+        lambda img: imgviz.draw.text_(img, yx=(0, 0), text="a", size=8),
+        lambda img: imgviz.draw.triangle_(img, center=(5, 5), size=4, fill=(255, 0, 0)),
+    ],
+    ids=[
+        "arrow",
+        "box_corners",
+        "circle",
+        "ellipse",
+        "line",
+        "pie",
+        "polygon",
+        "rectangle",
+        "rounded_rectangle",
+        "star",
+        "text",
+        "triangle",
+    ],
+)
+def test_in_place_primitives_reject_non_pil_image(
+    draw_: Callable[[NDArray[np.uint8]], None],
+) -> None:
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(TypeError, match="image must be PIL.Image.Image"):
+        draw_(image)


### PR DESCRIPTION
Closes #208.

Finishes what a28a708 started: that commit extracted the PIL-image guard into a helper and stopped at two callers, leaving twelve in-place primitives to fail inside Pillow with an unrelated error when handed a NumPy array. Since every primitive already constructs an `ImageDraw`, the guard now lives in that one construction and cannot be skipped.

One non-obvious bit: in the four primitives that already guarded, the guard ran before argument validation, and it still does, because the `ImageDraw` construction moved up to where the guard was; error precedence is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnENzL5E2cNdS973JnJMPy

