### PR TITLE
docs: define GitHub label workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Issues are tracked in GitHub Issues on `wkentaro/imgviz`, managed via the `gh` C
 
 ### Triage labels
 
-Five canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+Issue type, issue triage, and pull-request verdict labels follow `docs/agents/triage-labels.md`; consult it before routing issues or labeling PRs.
 
 ### Domain docs
 

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,15 +1,49 @@
-# Triage Labels
+# Triage and PR Labels
 
-The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+This repository uses the following labels to route issue and pull-request work.
 
-| Label in mattpocock/skills | Label in our tracker | Meaning |
-| -------------------------- | -------------------- | ---------------------------------------- |
-| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
-| `needs-info` | `needs-info` | Waiting on reporter for more information |
-| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
-| `ready-for-human` | `ready-for-human` | Requires human implementation |
-| `wontfix` | `wontfix` | Will not be actioned |
+## Issue type
 
-When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+Every triaged issue carries exactly one type label:
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+| Label | Meaning |
+| --- | --- |
+| `type: bug` | Reporting a defect to fix |
+| `type: feature` | Requesting a new capability or improvement |
+| `type: task` | Other work, including maintenance, refactoring, documentation, and tests |
+
+## Issue triage
+
+Every triaged issue carries exactly one triage label. An issue with no triage
+label is fresh work for the agent to route; `needs-triage` is reserved for a
+maintainer decision.
+
+| Role | Label | Meaning |
+| --- | --- | --- |
+| Maintainer evaluates | `needs-triage` | Maintainer needs to evaluate this issue |
+| Reporter provides information | `needs-info` | Waiting on the reporter for more information; shared with PRs |
+| Agent implements | `ready-for-agent` | Fully specified and ready for an AFK agent |
+| Human implements | `ready-for-human` | Requires human implementation |
+| Closed without action | `wontfix` | Will not be actioned |
+
+## Pull-request state and verdicts
+
+The native draft flag means that a PR is still being built or iterated. A
+non-draft PR with no verdict is fresh work for the agent to finalize. After the
+agent finalizes a PR, exactly one of these mutually exclusive agent verdicts is
+used:
+
+| Label | Meaning |
+| --- | --- |
+| `recommend-merge` | Agent finalized it and endorses review and merge |
+| `recommend-close` | Agent recommends closing it; the maintainer reviews or closes |
+| `recommend-triage` | Code is sound, but the maintainer must decide the product or scope question |
+
+`needs-info` is shared between issues and PRs when waiting on an outside human.
+`maintainer-approved` is a human-only verdict: a maintainer reviewed this exact
+PR head and approves merging after required checks pass. An agent must apply it
+only after explicit maintainer direction; it may coexist with an agent verdict.
+
+Verdict labels record decisions; they never merge or close a PR. A new commit
+makes every verdict stale, so its authority must remove the stale label and
+renew the applicable verdict for the new head.


### PR DESCRIPTION
Gives agents and maintainers one shared vocabulary for issue triage and pull-request decisions.

- Documents the `type:` and issue-triage axes, including exact cardinality rules.
- Documents draft state, the three agent PR verdicts, human-only `maintainer-approved`, and stale-label handling.
- Keeps the root agent guidance as a pointer to the durable contract.

GitHub labels were configured separately; no runtime code changed.
