### PR TITLE
refactor: drop redundant slicing and dead intermediates

### DIFF
--- a/imgviz/_flow.py
+++ b/imgviz/_flow.py
@@ -75,8 +75,7 @@ def _flow_compute_color(flow_u: NDArray, flow_v: NDArray) -> NDArray[np.uint8]:
         col[idx] = 1 - rad[idx] * (1 - col[idx])
         col[~idx] = col[~idx] * 0.75  # out of range?
 
-        ch_idx = i
-        flow_image[:, :, ch_idx] = np.floor(255 * col)
+        flow_image[:, :, i] = np.floor(255 * col)
 
     return flow_image
 

--- a/imgviz/_instances.py
+++ b/imgviz/_instances.py
@@ -100,12 +100,13 @@ def instances2rgb(
         colormap = _label.label_colormap()
 
     dst = image.copy()
+    instance_colors = colormap[1:]
 
     for mask, instance_id in zip([] if masks is None else masks, range(n_instance)):
         if mask.sum() == 0:
             continue
 
-        color_ins = colormap[1:][instance_id % len(colormap[1:])]
+        color_ins = instance_colors[instance_id % len(instance_colors)]
 
         # Each instance blends against the original image, not the running
         # result, so overlapping masks show the topmost color rather than a

--- a/imgviz/_label.py
+++ b/imgviz/_label.py
@@ -84,7 +84,7 @@ def label2rgb(
     max_label_id = max(int(unique_labels[-1]), 0)
 
     if isinstance(alpha, (int, float)):
-        alpha_arr = np.array([alpha for _ in range(max_label_id + 1)])
+        alpha_arr = np.full(max_label_id + 1, alpha, dtype=float)
     elif isinstance(alpha, dict):
         alpha_arr = np.array(
             [alpha.get(label_id, 0.5) for label_id in range(max_label_id + 1)]

--- a/imgviz/_resize.py
+++ b/imgviz/_resize.py
@@ -98,19 +98,15 @@ def resize(
 
     image_height, image_width = image.shape[:2]
     if isinstance(width, float):
-        scale_width = width
-        width = int(round(scale_width * image_width))
+        width = int(round(width * image_width))
     if isinstance(height, float):
-        scale_height = height
-        height = int(round(scale_height * image_height))
+        height = int(round(height * image_height))
     if height is None and width is None:
         raise ValueError("either height or width must be given")
     if height is None:
-        scale_height = width / image_width
-        height = int(round(scale_height * image_height))
+        height = int(round(width / image_width * image_height))
     if width is None:
-        scale_width = height / image_height
-        width = int(round(scale_width * image_width))
+        width = int(round(height / image_height * image_width))
 
     if backend == "pillow":
         dst = _resize_pillow(image, height, width, interpolation)


### PR DESCRIPTION
Closes #195. Mechanical sweep of the four items listed there; no logic change, existing suite green before and after. Item 1's wasted full-image allocation and in-loop copy were already removed by #309, so only the hoisted colormap slice remains from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnENzL5E2cNdS973JnJMPy
